### PR TITLE
fix typecasting table not being initialized in compiletime

### DIFF
--- a/wurst/_wurst/TypeCasting.wurst
+++ b/wurst/_wurst/TypeCasting.wurst
@@ -3,10 +3,11 @@ import NoWurst
 import _Handles
 import Table
 
-Table typecastdata
+constant Table typecastdata = new Table()
+	
 init
-	typecastdata = new Table()
 	typecastdata.saveString(0, "")
+
 
 public function stringToIndex(string s) returns int
 	let hash = s.getHash()


### PR DESCRIPTION
I made it a constant and made sure it is initialized right away in compiletime.