### PR TITLE
remove compiletime call in OnUnitEnterLeave

### DIFF
--- a/wurst/event/DamageDetection.wurst
+++ b/wurst/event/DamageDetection.wurst
@@ -9,7 +9,10 @@ integer funcNext = 0
 trigger current = null
 trigger toDestroy = null
 
-constant filter = Filter(() -> current.registerUnitEvent(GetFilterUnit(), EVENT_UNIT_DAMAGED))
+constant filter = Filter(() -> addUnit(GetFilterUnit()))
+
+function addUnit(unit u)
+	current.registerUnitEvent(u, EVENT_UNIT_DAMAGED)
 
 /** Add a Condition(Action) to the damage Event. */
 public function addOnDamageFunc(boolexpr cf)
@@ -25,7 +28,6 @@ public function disableDamageDetect()
 public function enableDamageDetect()
 	EnableTrigger(current)
 
-
 /** Periodic Cleanup-Function */
 function swap()
 	boolean b = IsTriggerEnabled(current)
@@ -40,17 +42,15 @@ function swap()
 	if not b
 		current.disable()
 
-
 	GroupEnumUnitsInRect(ENUM_GROUP, boundRect, filter)
 
 	for i = 0 to funcNext-1
 		current.addCondition(func[i])
-
 
 init
 	current = CreateTrigger()
 	for i = 0 to funcNext-1
 		current.addCondition(func[i])
-	onEnter(() -> filter)
-	GroupEnumUnitsInRect(ENUM_GROUP, boundRect, filter)
+
+	onEnter(() -> addUnit(getEnterLeaveUnit()))
 	CreateTimer().startPeriodic(SWAP_TIMEOUT, function swap)

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -49,9 +49,7 @@ init
 		players[i].setAbilityAvailable(ABILITY_ID, false)
 
 	// Create the enter event
-	CreateTrigger()..registerEnterRegion(boundRegion, Filter(() -> begin
-		prepareUnit(GetFilterUnit())
-	end))
+	CreateTrigger()..registerEnterRegion(boundRegion, Filter(() -> prepareUnit(GetFilterUnit())))
 
 	// Create the leave event
 	registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> begin

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -10,7 +10,6 @@ import AbilityObjEditing
 import RegisterEvents
 import ObjectIdGenerator
 import MapBounds
-
 import ClosureTimers
 
 /* 	Provides event API for units entering and leaving the map.

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -33,7 +33,7 @@ public function onLeave(code c)
 	eventTrigger.addAction(c)
 
 /* === Internals === */
-constant ABILITY_ID = compiletime(ABIL_ID_GEN.next())
+constant ABILITY_ID = ABIL_ID_GEN.next()
 
 function prepareUnit(unit u)
 	u..addAbility(ABILITY_ID)..makeAbilityPermanent(ABILITY_ID, true)

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -48,23 +48,23 @@ init
 	for i = 0 to bj_MAX_PLAYER_SLOTS-1
 		players[i].setAbilityAvailable(ABILITY_ID, false)
 
-	// Create the enter event
-	CreateTrigger()..registerEnterRegion(boundRegion, Filter(() -> prepareUnit(GetFilterUnit())))
-
-	// Create the leave event
-	registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> begin
-		let leavingUnit = GetTriggerUnit()
-		if leavingUnit.getAbilityLevel(ABILITY_ID) == 0
-			eventUnit = leavingUnit
-			eventTrigger.execute()
-			eventUnit = null
-	end)
-
-	// Process preplaced units
-	preplacedUnits.enumUnitsInRect(boundRect)
-	nullTimer(()-> begin
+	nullTimer(() -> begin
+		// Process preplaced units
+		preplacedUnits.enumUnitsInRect(boundRect)
 		ForGroup(preplacedUnits, () -> prepareUnit(GetEnumUnit()))
 		preplacedUnits..clear()..destr()
+
+		// Create the enter event
+		CreateTrigger()..registerEnterRegion(boundRegion, Filter(() -> prepareUnit(GetFilterUnit())))
+
+		// Create the leave event
+		registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> begin
+			let leavingUnit = GetTriggerUnit()
+			if leavingUnit.getAbilityLevel(ABILITY_ID) == 0
+				eventUnit = leavingUnit
+				eventTrigger.execute()
+				eventUnit = null
+		end)
 	end)
 
 @compiletime function generateAbility()

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -11,18 +11,20 @@ import RegisterEvents
 import ObjectIdGenerator
 import MapBounds
 
+import ClosureTimers
+
 /* 	Provides event API for units entering and leaving the map.
 	The event will also fire for preplaced units on the map. */
 
-constant eventTrigger = CreateTrigger()
-unit tempUnit = null
+let eventTrigger = CreateTrigger()
 let preplacedUnits = CreateGroup()
+unit eventUnit = null
 
 /* @API */
 
 /** Returns the unit that caused the enter/leave event to happen */
 public function getEnterLeaveUnit() returns unit
-	return tempUnit
+	return eventUnit
 
 /** Adds a callback that is run when a unit enters the map */
 public function onEnter(code c)
@@ -33,11 +35,13 @@ public function onLeave(code c)
 	eventTrigger.addAction(c)
 
 /* === Internals === */
-constant ABILITY_ID = ABIL_ID_GEN.next()
+constant ABILITY_ID = compiletime(ABIL_ID_GEN.next())
 
 function prepareUnit(unit u)
+	eventUnit = u
 	u..addAbility(ABILITY_ID)..makeAbilityPermanent(ABILITY_ID, true)
 	eventTrigger.evaluate()
+	eventUnit = null
 
 init
 	// Make the ability invisible to the player
@@ -46,24 +50,24 @@ init
 
 	// Create the enter event
 	CreateTrigger()..registerEnterRegion(boundRegion, Filter(() -> begin
-		tempUnit = GetFilterUnit()
-		prepareUnit(tempUnit)
-		tempUnit = null
+		prepareUnit(GetFilterUnit())
 	end))
 
 	// Create the leave event
 	registerPlayerUnitEvent(EVENT_PLAYER_UNIT_ISSUED_ORDER, () -> begin
 		let leavingUnit = GetTriggerUnit()
 		if leavingUnit.getAbilityLevel(ABILITY_ID) == 0
-			tempUnit = leavingUnit
+			eventUnit = leavingUnit
 			eventTrigger.execute()
-			tempUnit = null
+			eventUnit = null
 	end)
 
 	// Process preplaced units
 	preplacedUnits.enumUnitsInRect(boundRect)
-	ForGroup(preplacedUnits, () -> prepareUnit(GetEnumUnit()))
-	preplacedUnits..clear()..destr()
+	nullTimer(()-> begin
+		ForGroup(preplacedUnits, () -> prepareUnit(GetEnumUnit()))
+		preplacedUnits..clear()..destr()
+	end)
 
 @compiletime function generateAbility()
 	new AbilityDefinitionDefend(ABILITY_ID)


### PR DESCRIPTION
Apparently, ever since the order of compiletime calls has become deterministic, the compiletime(x) function is just messing things up. I had to remove this in order to get the same order in compiletime/game.