### PR TITLE
add GroupUtils and change Group.wurst to use its functionalities

### DIFF
--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -82,4 +82,4 @@ public function group.next() returns unit
 	return iterUnit
 	
 public function group.close()
-	this.destr()
+	this.release()

--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -68,18 +68,22 @@ public function group.getRandomUnit() returns unit
 
 group iterGroup
 
+/** Creates a new iterator for this group. */
 public function group.iterator() returns group
 	iterGroup = getGroup()
 	ForGroup(this, () -> iterGroup.addUnit(GetEnumUnit()))
 	return iterGroup
 
+/** Returns whether the iterator has the next item */
 public function group.hasNext() returns boolean
 	return FirstOfGroup(this) != null
-	
+
+/** Returns the next item from the iterator */
 public function group.next() returns unit
 	let iterUnit = FirstOfGroup(this)
 	GroupRemoveUnit(this, iterUnit) 
 	return iterUnit
 	
+/** Closes the iterator, releaseing the group */
 public function group.close()
 	this.release()

--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -33,7 +33,7 @@ public function group.removeUnit(unit u)
 	GroupRemoveUnit(this, u)
 	
 public function group.destr()
-	this.release()
+	DestroyGroup(this)
 	
 public function group.contains(unit u) returns boolean
 	return IsUnitInGroup(u, this)
@@ -66,7 +66,6 @@ public function group.getRandomUnit() returns unit
 	
 /* Group iterator */
 
-unit iterUnit
 group iterGroup
 
 public function group.iterator() returns group
@@ -75,10 +74,10 @@ public function group.iterator() returns group
 	return iterGroup
 
 public function group.hasNext() returns boolean
-	iterUnit = FirstOfGroup(this)
-	return iterUnit != null
+	return FirstOfGroup(this) != null
 	
 public function group.next() returns unit
+	let iterUnit = FirstOfGroup(this)
 	GroupRemoveUnit(this, iterUnit) 
 	return iterUnit
 	

--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -1,8 +1,7 @@
 package Group
 import NoWurst
 import Vectors
-import Printing
-import Integer
+import initlater GroupUtils
 
 /** Use this group for your non-nested group enum calls
 	and then iterate through the group via **for from** or
@@ -34,7 +33,7 @@ public function group.removeUnit(unit u)
 	GroupRemoveUnit(this, u)
 	
 public function group.destr()
-	DestroyGroup(this)
+	this.release()
 	
 public function group.contains(unit u) returns boolean
 	return IsUnitInGroup(u, this)
@@ -65,20 +64,23 @@ public function group.getRandomUnit() returns unit
 	end)
 	return randomSelected
 	
+/* Group iterator */
 
-// group iterator
+unit iterUnit
+group iterGroup
+
 public function group.iterator() returns group
-	bj_groupAddGroupDest = CreateGroup()
-	ForGroup(this, function GroupAddGroupEnum)
-	return bj_groupAddGroupDest
+	iterGroup = getGroup()
+	ForGroup(this, () -> iterGroup.addUnit(GetEnumUnit()))
+	return iterGroup
 
 public function group.hasNext() returns boolean
-	return FirstOfGroup(this) != null
+	iterUnit = FirstOfGroup(this)
+	return iterUnit != null
 	
 public function group.next() returns unit
-	let u = FirstOfGroup(this)
-	GroupRemoveUnit(this, u) 
-	return u
+	GroupRemoveUnit(this, iterUnit) 
+	return iterUnit
 	
 public function group.close()
-	DestroyGroup(this)
+	this.destr()

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -6,6 +6,7 @@ import HashMap
 import Execute
 import MagicFunctions
 import TypeCasting
+import Maths
 
 /*
     Groups are a necessary evil that exists in warcraft 3, and sometimes their use
@@ -27,39 +28,62 @@ import TypeCasting
 /** The number of groups created at start */
 @configurable constant START_CREATE_GROUPS = 64
 
-/* Group instantiation */
-
-/** The total number of recyclable groups created by GroupUtils */
-
 let used = new HashMap<group, bool>
 group array stack
 var numStack = 0
 var numTotal = 0
 
+/* API */
+
+/** Returns a reusable group from the GroupUtils stack is possible.
+    Creates new groups if none are found on the reusable stack.
+    If that is not possible, returns a non-recyclable group and displays a warning. */
+public function getGroup() returns group
+    group retVal
+    if numStack > 0
+        retVal = pop()
+    else if numStack <= 0 and numTotal < GROUP_NUMBER_LIMIT 
+        createGroups(NEED_CREATE_GROUPS)
+        retVal = pop()
+    else
+        retVal = CreateGroup()
+    return retVal
+
+/** Recycles a group if it is created through GroupUtils, otherwise just destroys it. 
+    Doesn't affect ENUM_GROUP. */
+public function group.release()
+    if this == ENUM_GROUP
+        Log.warn("Attemping to release ENUM_GROUP!")
+    else
+        if this.isRecyclable()
+            if this.isUsed()
+                this.recycle()
+            else
+                Log.warn("Attemping to release an already released group!")
+        else
+            this.clear()
+            this.destr()
+
+/* Group instantiation */
+
 var shownMaxError = false
 
 function createGroups(int number)
     let maxCreatePerCycle = 256
-    let actualLimit = IMinBJ(8191, GROUP_NUMBER_LIMIT)
+    let actualLimit = max(8191, GROUP_NUMBER_LIMIT)
     let numTarget = numTotal + number 
-    let overflow  = IMaxBJ(0, numTarget - actualLimit)
-    var toCreate  = IMaxBJ(0, numTarget - overflow)
+    let overflow  = max(0, numTarget - actualLimit)
+    var toCreate  = max(0, numTarget - overflow)
 
     while toCreate > 0
-        let createNow = IMinBJ(toCreate, maxCreatePerCycle)
+        let createNow = min(toCreate, maxCreatePerCycle)
         toCreate -= createNow
 
-        if compiletime 
+        execute(() -> begin 
             numTotal += createNow
             for i = 1 to createNow
-                let g = CreateGroup()
-                push(g)
-        else
-            execute(() -> begin 
-                numTotal += createNow
-                for i = 1 to createNow
-                    push(CreateGroup())
-            end)
+                push(CreateGroup())
+        end)
         
     if numTotal >= GROUP_NUMBER_LIMIT and not shownMaxError
         Log.warn("Maximum number of GroupUtils groups (" + GROUP_NUMBER_LIMIT.toString() + ") created. "
@@ -102,33 +126,3 @@ function pop() returns group
 function group.recycle()
     this.clear()
     push(this)
-
-/** Returns a reusable group from the GroupUtils stack is possible.
-    Creates new groups if none are found on the reusable stack.
-    If that is not possible, returns a non-recyclable group and displays a warning. */
-public function getGroup() returns group
-    group retVal = null
-    if numStack > 0
-        retVal = pop()
-    else if numStack <= 0 and numTotal < GROUP_NUMBER_LIMIT 
-        createGroups(NEED_CREATE_GROUPS)
-        retVal = pop()
-    else
-        retVal = CreateGroup()
-    return retVal
-
-/** Recycles a group if it is created through GroupUtils, otherwise just destroys it. 
-    Doesn't affect ENUM_GROUP. 
-    Called by group.destr() */
-public function group.release()
-    if this == ENUM_GROUP
-        Log.warn("Attemping to release ENUM_GROUP!")
-    else
-        if this.isRecyclable()
-            if this.isUsed()
-                this.recycle()
-            else
-                Log.warn("Attemping to release an already released group!")
-        else
-            this.clear()
-            DestroyGroup(this)

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -1,0 +1,134 @@
+package GroupUtils
+import NoWurst
+import Group
+import ErrorHandling
+import HashMap
+import Execute
+import MagicFunctions
+import TypeCasting
+
+/*
+    Groups are a necessary evil that exists in warcraft 3, and sometimes their use
+    cannot be easily replicated or avoided, especially with nested enums.
+
+    However, for most purposes, if you want to keep a list of units and iterate over them
+    often, you should use LinkedList<unit> instead of the group, since LinkedList<unit>
+    provides more predictable and consistent functionalities that can be extended more easily.
+*/
+
+/** The max number of recyclable groups. Even if this number is reached, 
+    the system will create new groups on following requests, but they won't be recyclable.
+    The maximum number for this setting is 8191. */
+@configurable constant GROUP_NUMBER_LIMIT = 1024
+
+/** The number of groups created when more are needed */
+@configurable constant NEED_CREATE_GROUPS = 64
+
+/** The number of groups created at start */
+@configurable constant START_CREATE_GROUPS = 64
+
+/* Group instantiation */
+
+/** The total number of recyclable groups created by GroupUtils */
+
+let used = new HashMap<group, bool>
+group array stack
+var numStack = 0
+var numTotal = 0
+
+var shownMaxError = false
+
+function createGroups(int number)
+    let maxCreatePerCycle = 256
+    let actualLimit = IMinBJ(8191, GROUP_NUMBER_LIMIT)
+    let numTarget = numTotal + number 
+    let overflow  = IMaxBJ(0, numTarget - actualLimit)
+    var toCreate  = IMaxBJ(0, numTarget - overflow)
+
+    while toCreate > 0
+        let createNow = IMinBJ(toCreate, maxCreatePerCycle)
+        toCreate -= createNow
+
+        if compiletime 
+            numTotal += createNow
+            for i = 1 to createNow
+                let g = CreateGroup()
+                push(g)
+        else
+            execute(() -> begin 
+                numTotal += createNow
+                for i = 1 to createNow
+                    push(CreateGroup())
+            end)
+        
+    if numTotal >= GROUP_NUMBER_LIMIT and not shownMaxError
+        Log.warn("Maximum number of GroupUtils groups (" + GROUP_NUMBER_LIMIT.toString() + ") created. "
+            + "All newly created groups will be non-recyclable.")
+        shownMaxError = true
+
+init
+    createGroups(START_CREATE_GROUPS)
+
+/** Returns whether this group was created through GroupUtils. */
+function group.isRecyclable() returns bool
+    return used.has(this)
+
+/** Returns whether this group is currently being used */
+function group.isUsed() returns bool
+    return used.get(this)
+
+/* Stack operations */
+
+function push(group g)
+    stack[numStack] = g
+    used.put(stack[numStack], false)
+    numStack++
+
+bool shownDestrWarning = false
+
+function pop() returns group
+    numStack--
+    var retVal = stack[numStack]
+    
+    if stack[numStack] != null
+        used.put(stack[numStack], true)
+    else
+        if not shownDestrWarning
+            Log.warn("Groups on the GroupUtils stack shouldn't be destroyed! Use .release() instead.")
+            shownDestrWarning = true
+        retVal = getGroup()
+    return retVal
+
+function group.recycle()
+    this.clear()
+    push(this)
+
+/** Returns a reusable group from the GroupUtils stack is possible.
+    Creates new groups if none are found on the reusable stack.
+    If that is not possible, returns a non-recyclable group and displays a warning. */
+public function getGroup() returns group
+    group retVal = null
+    if numStack > 0
+        retVal = pop()
+    else if numStack <= 0 and numTotal < GROUP_NUMBER_LIMIT 
+        createGroups(NEED_CREATE_GROUPS)
+        retVal = pop()
+    else
+        retVal = CreateGroup()
+    return retVal
+
+/** Recycles a group if it is created through GroupUtils, otherwise just destroys it. 
+    Doesn't affect ENUM_GROUP. 
+    Called by group.destr() */
+public function group.release()
+    if this == ENUM_GROUP
+        Log.warn("Attemping to release ENUM_GROUP!")
+    else
+        if this.isRecyclable()
+            if this.isUsed()
+                this.recycle()
+            else
+                Log.warn("Attemping to release an already released group!")
+        else
+            this.clear()
+            DestroyGroup(this)

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -90,8 +90,11 @@ function createGroups(int number)
             + "All newly created groups will be non-recyclable.")
         shownMaxError = true
 
-init
+@compiletime function initialize()
     createGroups(START_CREATE_GROUPS)
+
+init
+    initialize()
 
 /** Returns whether this group was created through GroupUtils. */
 function group.isRecyclable() returns bool


### PR DESCRIPTION
Also, .destr() now calls .release()
The code is tested in game, and it works with my systems (that use a bunch of groups) without leaking. I can't guarantee more than that. This is impossible to test because get handle id is unavailable during compiletime. This also breaks GroupTests.wurst because it now uses getGroup() during group iteration.