### PR TITLE
add the ability to retrieve set ids from definitions

### DIFF
--- a/wurst/objediting/AbilityObjEditing.wurst
+++ b/wurst/objediting/AbilityObjEditing.wurst
@@ -13,7 +13,7 @@ public interface TooltipGenerator
 		
 public class AbilityDefinition
 	protected ObjectDefinition def
-	int lvls = 1
+	protected int lvls = 1
 	
 	TooltipGenerator tooltipGen = null
 	boolean listen = false
@@ -27,6 +27,9 @@ public class AbilityDefinition
 	function getBaseId() returns int
 		return baseId
 
+	function getLevels() returns int
+		return lvls
+
 	construct(int newId, int baseId)
 		this.newId = newId
 		this.baseId = baseId
@@ -35,6 +38,7 @@ public class AbilityDefinition
 	construct(int newId, int baseId, int lvls)
 		this.newId = newId
 		this.baseId = baseId
+		this.lvls = lvls
 		def = createObjectDefinition("w3a", newId, baseId)
 		setLevels(lvls)
 

--- a/wurst/objediting/AbilityObjEditing.wurst
+++ b/wurst/objediting/AbilityObjEditing.wurst
@@ -18,13 +18,26 @@ public class AbilityDefinition
 	TooltipGenerator tooltipGen = null
 	boolean listen = false
 	
-	construct(int newAbilityId, int origAbilityId)
-		def = createObjectDefinition("w3a", newAbilityId, origAbilityId)
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3a", newId, baseId)
 		
-	construct(int newAbilityId, int origAbilityId, int lvls)
-		def = createObjectDefinition("w3a", newAbilityId, origAbilityId)
+	construct(int newId, int baseId, int lvls)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3a", newId, baseId)
 		setLevels(lvls)
-		
+
 	function addTooltipProperty(string pName, StringLevelClosure lc)
 		if tooltipGen != null and listen
 			tooltipGen.addProperty(pName, lc)

--- a/wurst/objediting/BuffObjEditing.wurst
+++ b/wurst/objediting/BuffObjEditing.wurst
@@ -4,9 +4,20 @@ import ObjEditingNatives
 public class BuffDefinition
 	ObjectDefinition def
 	
-	construct(int newAbilityId, int origAbilityId)
-		def = createObjectDefinition("w3h", newAbilityId, origAbilityId)
-	
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3h", newId, baseId)
+
 	function setName(int level, string value)
 		def.setLvlDataString("fnam",  level, 0,  value)
 

--- a/wurst/objediting/DestructableObjEditing.wurst
+++ b/wurst/objediting/DestructableObjEditing.wurst
@@ -6,8 +6,19 @@ import NoWurst
 public class W3BDefinition
 	ObjectDefinition def
 	
-	construct(int newDestrID, int origDestrID)
-		def = createObjectDefinition("w3b",newDestrID,origDestrID)
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3b", newId, baseId)
 		
 public class DestructableDefinition extends W3BDefinition
 	construct(int newID,int origID)

--- a/wurst/objediting/ItemObjEditing.wurst
+++ b/wurst/objediting/ItemObjEditing.wurst
@@ -6,8 +6,19 @@ import NoWurst
 public class W3TDefinition
 	ObjectDefinition def
 	
-	construct(int newUnitId, int origUnitId)
-		def = createObjectDefinition("w3t", newUnitId, origUnitId)
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3t", newId, baseId)
 				
 	function setTooltipExtended(string data)
 		def.setString("utub", data)

--- a/wurst/objediting/UnitObjEditing.wurst
+++ b/wurst/objediting/UnitObjEditing.wurst
@@ -241,8 +241,19 @@ public function MovementType.toObjectString() returns string
 public class W3UDefinition
 	ObjectDefinition def
 	
-	construct(int newUnitId, int origUnitId)
-		def = createObjectDefinition("w3u", newUnitId, origUnitId)
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3u", newId, baseId)
 				
 	function setTooltipExtended(string data)
 		def.setString("utub", data)

--- a/wurst/objediting/UpgradeObjEditing.wurst
+++ b/wurst/objediting/UpgradeObjEditing.wurst
@@ -5,8 +5,19 @@ import NoWurst
 public class W3QDefinition
 	ObjectDefinition def
 	
-	construct(int newUnitId, int origUnitId)
-		def = createObjectDefinition("w3q", newUnitId, origUnitId)
+	protected int newId 
+	protected int baseId
+
+	function getNewId() returns int
+		return newId
+
+	function getBaseId() returns int
+		return baseId
+
+	construct(int newId, int baseId)
+		this.newId = newId
+		this.baseId = baseId
+		def = createObjectDefinition("w3q", newId, baseId)
 				
 	function setTooltipExtended(string data)
 		def.setString("utub", data)


### PR DESCRIPTION
This is code that I've been using for a while but always put off adding it to the stdlib. My idea is to make data directly set by the constructor retrievable afterwards, this makes it easier to create object data frameworks since it allows you to pass newly constructed definitions as parameters, and then have your system decide what to do with the ids (and where and how to store them).