### PR TITLE
Improvements to FileIO and Network packages

### DIFF
--- a/wurst/_handles/primitives/Boolean.wurst
+++ b/wurst/_handles/primitives/Boolean.wurst
@@ -7,10 +7,21 @@ public function boolean.toString() returns string
 	if this
 		result = "true"
 	return result
-	
+
+/** Converts this string into a boolean */
+public function string.toBool() returns boolean
+	var result = false
+	if this == "1" or this == "true"
+		result = true
+	return result
+
 /** Converts this boolean into an int */
 public function boolean.toInt() returns int
 	var result = 0
 	if this
 		result = 1
 	return result
+
+/** Converts this int into a boolean */
+public function int.toBool() returns boolean
+	return this != 0

--- a/wurst/_wurst/ErrorHandling.wurst
+++ b/wurst/_wurst/ErrorHandling.wurst
@@ -18,6 +18,13 @@ constant HT = InitHashtable()
 **/
 public string lastError = null
 
+/**
+	Allows you to suppress error output.
+	This is primarily useful when you catch
+	an error with try().
+**/
+public boolean suppressErrorMessages = false
+
 /** error handing function.
 This function is used by libraries and for internal Wurst errors like 
 accessing a null-pointer. Overwrite this function to customize error handling.
@@ -35,24 +42,25 @@ You can also use try() from package Execute to handle an error happening in a ca
 	if compiletime
 		print("ERROR: " + msg + "\n" + getStackTraceString())
 	else
-		let hash = msg.getHash()
-		if HT.hasInt(PRIMARY_ERROR_KEY, hash)
-			// Error has been printed before
-			if HT.loadInt(PRIMARY_ERROR_KEY, hash) + MUTE_ERROR_DURATION < currentTime
-				// Time to print the error again
-				Log.error(msg + getStackTraceString())
-				HT.saveInt(PRIMARY_ERROR_KEY, hash, currentTime.toInt())
-				HT.saveBoolean(PRIMARY_ERROR_KEY, hash, false)
-			else if HT.hasBoolean(PRIMARY_ERROR_KEY, hash)
-				if not HT.loadBoolean(PRIMARY_ERROR_KEY, hash)
+		if not suppressErrorMessages
+			let hash = msg.getHash()
+			if HT.hasInt(PRIMARY_ERROR_KEY, hash)
+				// Error has been printed before
+				if HT.loadInt(PRIMARY_ERROR_KEY, hash) + MUTE_ERROR_DURATION < currentTime
+					// Time to print the error again
+					Log.error(msg + getStackTraceString())
+					HT.saveInt(PRIMARY_ERROR_KEY, hash, currentTime.toInt())
+					HT.saveBoolean(PRIMARY_ERROR_KEY, hash, false)
+				else if HT.hasBoolean(PRIMARY_ERROR_KEY, hash)
+					if not HT.loadBoolean(PRIMARY_ERROR_KEY, hash)
+						Log.error("|cffFF3A29Excessive repeating errors are being omitted")
+						HT.saveBoolean(PRIMARY_ERROR_KEY, hash, true)	
+				else
 					Log.error("|cffFF3A29Excessive repeating errors are being omitted")
 					HT.saveBoolean(PRIMARY_ERROR_KEY, hash, true)	
 			else
-				Log.error("|cffFF3A29Excessive repeating errors are being omitted")
-				HT.saveBoolean(PRIMARY_ERROR_KEY, hash, true)	
-		else
-			HT.saveInt(PRIMARY_ERROR_KEY, hash, currentTime.toInt())
-			Log.error("|cffFF3A29Error:|r " + msg + getStackTraceString())
+				HT.saveInt(PRIMARY_ERROR_KEY, hash, currentTime.toInt())
+				Log.error("|cffFF3A29Error:|r " + msg + getStackTraceString())
 		// crash the thread:
 		lastError = msg
 		I2S(1 div 0)

--- a/wurst/closures/Execute.wurst
+++ b/wurst/closures/Execute.wurst
@@ -84,14 +84,20 @@ public function execute(ForForceCallback c)
 	the only difference that it will allow you to inspect
 	an error if one occured.
 
+	If an error occured, the return value will be false.
+
 	If the error is caused by error(), then you can inspect
 	the error message using lastError from ErrorHandling.
 	If the error is caused by another form of thread crash,
 	such as zero division or OP limit, lastError will be null.
+
+	The error will also be suppressed from being printed.
 **/
 public function try(ForForceCallback c) returns boolean
 	pushCallback(c)
+	let suppressErrors = suppressErrorMessages
 	executeForce.forEach(function executeCurrentCallback)
+	suppressErrorMessages = suppressErrors
 	popCallback()
 	return isLastCallbackSuccessful()
 

--- a/wurst/data/BufferAdapters.wurst
+++ b/wurst/data/BufferAdapters.wurst
@@ -2,7 +2,7 @@ package BufferAdapters
 
 import Buffer
 import Execute
-import MultiIO
+import MultifileIO
 
 function StringBuffer.transferValueTo(HashBuffer sink)
 	let valueType = this.peekType()

--- a/wurst/file/LocalFiles.wurst
+++ b/wurst/file/LocalFiles.wurst
@@ -96,5 +96,5 @@ public class LocalFiles
 		end)
 
 init
-	doAfter(0, () -> LocalFiles.checkAll())
+	nullTimer(() -> LocalFiles.checkAll())
 	

--- a/wurst/file/LocalFiles.wurst
+++ b/wurst/file/LocalFiles.wurst
@@ -1,0 +1,100 @@
+package LocalFiles
+
+import PreloadIO
+import ClosureTimers
+import Network
+import ErrorHandling
+
+/**
+	Utility class used to check if the LocalFiles registry property of the
+	player is enabled.
+
+	In other words, this checks if the user can reliably write/read files.
+	This also includes a fallback mechanism for the 1.26 patch and before,
+	which uses the Logs\ folder to write files in.
+**/
+public class LocalFiles
+	private static constant testDestination = "localtest.txt"
+	private static constant fallbackDestination = "Logs\\localtest.txt"
+	private static constant testString = "test"
+
+	private static var checked = false
+	private static var checkedAll = false
+	private static var enabled = false
+	private static var fallback = false
+	private static boolean array enabledPlayers
+
+	/** 
+		Checks whether Local Files are enabled for this local player. 
+		You should not call this function too early in your init,
+		because the check might not have completed yet.
+	**/
+	static function isEnabled() returns boolean
+		if not checked
+			error("Trying to check Local Files too early. You should delay your init.")
+		return enabled
+
+	static function isEnabled(player who) returns boolean
+		if not checkedAll
+			error("Trying to check Local Files too early. You should delay your init.")
+		return enabledPlayers[who.getId()]
+
+	/** Checks whether 1.26 patch fallback is enabled. **/
+	static function isFallback() returns boolean
+		return fallback
+		
+	/** 
+		Performs the actual checking for this local player.
+		This function is only meant to be called once.
+	**/
+	private static function check()
+		// try regular writing/reading first
+		IOWriter.prepareWrite()
+		IOWriter.writePacket(testString)
+		IOWriter.flushFile(testDestination)
+		IOReader.load(testDestination)
+		if IOReader.getPacket(0) == testString
+			enabled = true
+			return
+	
+		// now try 1.26 fallback
+		IOWriter.prepareWrite()
+		IOWriter.writePacket(testString)
+		IOWriter.flushFile(fallbackDestination)
+		IOReader.load(fallbackDestination)
+		if IOReader.getPacket(0) == testString
+			enabled = true
+			fallback = true
+			return
+		
+		checked = true
+
+	/**
+		Performs the checking for all players,
+		and sends the results to others.
+	**/
+	protected static function checkAll()
+		let synchronizer = new SimpleSynchronizer()
+		check()
+
+		for i = 0 to 11
+			enabledPlayers[i] = false
+			let network = new Network(players[i])
+			network.getData().writeBoolean(LocalFiles.isEnabled())
+			network.start((NetworkResult status, Buffer data) -> begin
+				if status == NetworkResult.SUCCESS
+					enabledPlayers[i] = data.readBoolean()
+				else
+					enabledPlayers[i] = false
+
+				if players[i] == localPlayer
+					synchronizer.sync()
+			end)
+
+		synchronizer.onSynced(() -> begin
+			checkedAll = true
+		end)
+
+init
+	doAfter(0, () -> LocalFiles.checkAll())
+	

--- a/wurst/file/MultifileIO.wurst
+++ b/wurst/file/MultifileIO.wurst
@@ -16,10 +16,7 @@ function getChunkPath(string path, int id) returns string
 	return path + "/chunk" + id.toString() + ".txt"
 
 function getBasePath() returns string
-	var path = ""
-	if LocalFiles.isFallback()
-		path = "Logs\\"
-	return path
+	return LocalFiles.isFallback() ? "Logs\\" : ""
 
 /**
 	Represents the status of a file operation.

--- a/wurst/file/MultifileIO.wurst
+++ b/wurst/file/MultifileIO.wurst
@@ -1,9 +1,10 @@
-package MultiIO
+package MultifileIO
 
-import SimpleIO
+import PreloadIO
 import ErrorHandling
 import Buffer
 import IOTaskExecutor
+import LocalFiles
 
 class FilePacket
 	string packet
@@ -14,7 +15,24 @@ class FilePacket
 function getChunkPath(string path, int id) returns string
 	return path + "/chunk" + id.toString() + ".txt"
 
-public interface FileCallback
+function getBasePath() returns string
+	var path = ""
+	if LocalFiles.isFallback()
+		path = "Logs\\"
+	return path
+
+/**
+	Represents the status of a file operation.
+	NOT_ENABLED corresponds to Local Files not being enabled for the player.
+**/
+public enum FileLoadStatus
+	SUCCESS
+	NOT_ENABLED
+
+public interface FileLoadCallback
+	function run(FileLoadStatus status)
+
+public interface FileSaveCallback
 	function run()
 
 /**
@@ -129,7 +147,7 @@ public class FileWriter extends AbstractFile
 	/**
 		Starts saving the queue data to disk, and specifies a callback when all data has been saved.
 	**/
-	function save(FileCallback callback)
+	function save(FileSaveCallback callback)
 		if working
 			error("FileWriter: trying to save the file, but it is already saving")
 
@@ -215,13 +233,16 @@ public class FileReader extends AbstractFile
 	/**
 		Starts loading the file and specifies a callback to be called when all data has loaded
 	**/
-	function load(FileCallback callback)
+	function load(FileLoadCallback callback)
+		if not LocalFiles.isEnabled()
+			callback.run(FileLoadStatus.NOT_ENABLED)
+
 		if working
 			error("FileReader: trying to load the file, but it is already loading")
 
 		executor.onComplete(() -> begin
 			working = false
-			callback.run()
+			callback.run(FileLoadStatus.SUCCESS)
 		end)
 		// initiate reading, since readChunk will load other chunks as necessary
 		readChunk(0)

--- a/wurst/file/Persistable.wurst
+++ b/wurst/file/Persistable.wurst
@@ -16,7 +16,7 @@ import LocalFiles
 	This can also happen if the file is empty or doesn't exist.
 	FAIL_NO_PLAYER - The player has left either during data transfer, or before.
 **/
-enum LoadStatus
+public enum LoadStatus
 	SUCCESS
 	FAIL_NOT_ENABLED
 	FAIL_FILE_CORRUPT
@@ -29,7 +29,7 @@ enum LoadStatus
 	FAIL_NOT_ENABLED - Local files have not been enabled for this user.
 	FAIL_NO_PLAYER - The player is not present.
 **/
-enum SaveStatus
+public enum SaveStatus
 	SUCCESS
 	FAIL_NOT_ENABLED
 	FAIL_NO_PLAYER

--- a/wurst/file/Persistable.wurst
+++ b/wurst/file/Persistable.wurst
@@ -1,9 +1,38 @@
 package Persistable
 import Network
-import MultiIO
-import SimpleIO
+import MultifileIO
+import PreloadIO
 import BufferAdapters
 import public Buffer
+import LocalFiles
+
+/**
+	Represents the various states of a persistable class load.
+	SUCCESS - The class has successfully loaded from disk.
+	FAIL_NOT_ENABLED - Local files have not been enabled for this user.
+	FAIL_FILE_CORRUPT - Decoding failed due to a corrupted/tampered file.
+	FAIL_DESERIALIZE - Decoding failed due to bad data in the file, meaning the .deserialize()
+	function errored out due to missing/malformed data after it has been succesfully decoded.
+	This can also happen if the file is empty or doesn't exist.
+	FAIL_NO_PLAYER - The player has left either during data transfer, or before.
+**/
+enum LoadStatus
+	SUCCESS
+	FAIL_NOT_ENABLED
+	FAIL_FILE_CORRUPT
+	FAIL_DESERIALIZE
+	FAIL_NO_PLAYER
+
+/**
+	Represents the various states of a persistable class save.
+	SUCCESS - The class has successfully saved to disk.
+	FAIL_NOT_ENABLED - Local files have not been enabled for this user.
+	FAIL_NO_PLAYER - The player is not present.
+**/
+enum SaveStatus
+	SUCCESS
+	FAIL_NOT_ENABLED
+	FAIL_NO_PLAYER
 
 /**
 	This is the folder that all your map objects will be serialized in.
@@ -14,7 +43,7 @@ constant PERSISTABLE_MAP_PREFIX = "persistent"
 
 /** Functional interface for optional lambda callback in Persistable.load() **/
 public interface PersistableLoadCallback
-	function onLoaded(boolean success)
+	function onLoaded(LoadStatus status)
 
 /** Functional interface for optional lambda callback in Persistable.save() **/
 public interface PersistableSaveCallback
@@ -42,13 +71,13 @@ public abstract class Persistable implements BufferSerializable
 	abstract function getClassId() returns string
 	/** This function should return a unique object id for this instance **/
 	abstract function getId() returns string
-	/** This function should apply default settings in the event that loading has failed **/
+	/** This function should apply default data in the event that loading has failed **/
 	abstract function supplyDefault()
 
 	/* Optionally overridable functions */
 
 	/** Override this function if you want to do something on object load **/
-	protected function onLoaded(boolean _success)
+	protected function onLoaded(LoadStatus _status)
 	/** Override this function if you want to do something on object save **/
 	protected function onSaved()
 	/** 
@@ -96,20 +125,32 @@ class PersistentStore
 		this.entity = entity
 		this.owner = owner
 
+	private function finishWithStatus(LoadStatus status, PersistableLoadCallback callback)
+		if status != LoadStatus.SUCCESS
+			entity.supplyDefault()
+		
+		if callback != null
+			callback.onLoaded(status)
+		entity.onLoaded(status)
+
 	function load(PersistableLoadCallback callback)
+		if not LocalFiles.isEnabled(owner)
+			finishWithStatus(LoadStatus.FAIL_NOT_ENABLED, callback)
+			return
+
 		// synchronizer used to proceed when the owner has finished loading data
 		let synchronizer = new SimpleSynchronizer()
 		let network = new Network(owner)
 		let reader = new FileReader(entity.getPath(), entity.getIODelay())
 	
 		if localPlayer == owner
-			reader.load(() -> begin
+			reader.load((FileLoadStatus _status) -> begin
 				var buffer = new StringBuffer(MAX_PACKET_LENGTH)
 				// a boolean for keeping track of whether the load was succesful or not
 				network.getData().writeBoolean(true)
 				// read the data from the file into the buffer, and then transfer it into the network's buffer
 				buffer.populateFromFile(reader)
-				buffer.transfer(network.getData())
+				try(() -> buffer.transfer(network.getData()))
 				// if there was an error during transfer, we scrap the data...
 				if not buffer.isValid()
 					network.getData().clear()
@@ -126,21 +167,24 @@ class PersistentStore
 		synchronizer.onSynced(() -> begin
 			destroy reader
 
-			network.start((Buffer buffer) -> begin
-				// first boolean in the stream is always an indicator of whether the owner loaded succesfully
-				let success = buffer.readBoolean()
-				
-				if success
-					// if the deserialization has failed for some reason, we need to catch that
-					let deserializeSuccess = try(() -> entity.deserialize(buffer))
-					if not deserializeSuccess
-						entity.supplyDefault()
-				else
-					entity.supplyDefault()
+			network.start((NetworkResult status, Buffer buffer) -> begin
+				var loadStatus = LoadStatus.SUCCESS
 
-				if callback != null
-					callback.onLoaded(success)
-				entity.onLoaded(success)
+				if status == NetworkResult.ABORTED
+					loadStatus = LoadStatus.FAIL_NO_PLAYER
+				else
+					// first boolean in the stream is always an indicator of whether the owner loaded succesfully
+					let decodeSuccess = buffer.readBoolean()
+					
+					if decodeSuccess
+						// if the deserialization has failed for some reason, we need to catch that
+						let deserializeSuccess = try(() -> entity.deserialize(buffer))
+						if not deserializeSuccess
+							loadStatus = LoadStatus.FAIL_DESERIALIZE
+					else
+						loadStatus = LoadStatus.FAIL_FILE_CORRUPT
+
+				finishWithStatus(loadStatus, callback)
 			end)
 		end)
 

--- a/wurst/file/PreloadIO.wurst
+++ b/wurst/file/PreloadIO.wurst
@@ -1,8 +1,20 @@
-package SimpleIO
+/**
+	This package is meant to provide a primitive wrapper around the
+	Preload API of WC3 to be able to read and write files.
+
+	This package is not meant to handle Local Files setting in WC3,
+	nor is it meant to handle 1.26 version adjustment.
+
+	This functionality is provided in the LocalFiles package,
+	and is handled by other packages in the file subsystem.
+
+	If you want to read/write in 1.26 with local files, 
+	you will need to prepend "Logs\\" to your paths.
+**/
+package PreloadIO
 
 import ErrorHandling
 import StringUtils
-import ClosureTimers
 
 /** Maximum amount of packets per single readable file. */
 public constant PACKETS_PER_FILE = 16 	
@@ -54,10 +66,7 @@ public class IOWriter
 	/** Flushes a file and all written content to disk under the specified path. */
 	static function flushFile(string path)
 		Preload(DATA_FOOTER)
-		if LocalFiles.fallback
-			PreloadGenEnd("Logs\\" + path)
-		else
-			PreloadGenEnd(path)
+		PreloadGenEnd(path)
 
 	/** Returns the amount of packets we can write to the current file. */
 	static function getRemainingWrites() returns int
@@ -70,7 +79,7 @@ public class IOWriter
 	/**
 		Recursively creates the specified folder. 
 		Necessary because WC3 doesn't automatically 
-		creat nested folders and fails silently. 
+		create nested folders and fails silently. 
 	**/
 	static function createFolder(string path)
 		var current = ""
@@ -111,10 +120,7 @@ public class IOReader
 		packetNumber = 0
 		packetCount = 0
 		saveNames()
-		if LocalFiles.fallback
-			Preloader("Logs\\" + path)
-		else
-			Preloader(path)
+		Preloader(path)
 
 		for i = 0 to PACKETS_PER_FILE - 1
 			if playerNames[i] != players[i].getName()
@@ -144,63 +150,3 @@ public class IOReader
 	/** Returns whether there are any packets left to be read from the currently loaded file. */
 	static function canRead() returns boolean
 		return getRemainingReads() > 0
-
-/**
-	Utility class used to check if the LocalFiles registry property of the
-	player is enabled.
-
-	In other words, this checks if the user can reliably write/read files.
-	This also includes a fallback mechanism for the 1.26 patch and before,
-	which uses the Logs\ folder to write files in.
-**/
-public class LocalFiles
-	private static constant testDestination = "localtest.txt"
-	private static constant fallbackDestination = "Logs\\localtest.txt"
-	private static constant testString = "test"
-
-	protected static var checked = false
-	protected static var enabled = false
-	protected static var fallback = false
-
-	static function isEnabled() returns boolean
-		if checked
-			return enabled
-		else
-			check()
-			return enabled
-
-	static function isFallback() returns boolean
-		if checked
-			return fallback
-		else
-			check()
-			return fallback
-		
-	protected static function check()
-		// try regular writing/reading first
-		IOWriter.prepareWrite()
-		IOWriter.writePacket(testString)
-		IOWriter.flushFile(testDestination)
-		IOReader.load(testDestination)
-		if IOReader.getPacket(0) == testString
-			checked = true
-			enabled = true
-			return
-	
-		// now try 1.26 fallback
-		IOWriter.prepareWrite()
-		IOWriter.writePacket(testString)
-		IOWriter.flushFile(fallbackDestination)
-		IOReader.load(fallbackDestination)
-		if IOReader.getPacket(0) == testString
-			checked = true
-			enabled = true
-			fallback = true
-			return
-		
-		checked = true
-
-init
-	// force a check as soon as possible to trigger 1.26 detection
-	doAfter(0, () -> LocalFiles.check())
-	

--- a/wurst/network/Network.wurst
+++ b/wurst/network/Network.wurst
@@ -1,22 +1,9 @@
-package Network
-
-import public SyncSimple
-import ErrorHandling
-import public Execute
-import public Buffer
-
-import NetworkConfig
-import Metadata
-import GamecacheKeys
-import GamecacheBuffer
-import StringEncoder
-
 /********************************************************************************
 	Network library by MoriMori.
 
 	Based on TriggerHappy's Sync library.
 
-	Rationale:
+	Overview:
 		In multiplayer games, this package is for synchronizing data between game clients.
 		It's useful for when one player is the source of game data, such as from gamecache or file IO.
 
@@ -37,8 +24,8 @@ import StringEncoder
 		methods of the HashBuffer class.
 
 		Before sending the data, the sender populates the HashBuffer with the data that
-		they want to send, then Network.start() is called, as well as Network.onFinish(callback)
-		and data is received from the same buffer inside the callback when it has all been received.
+		they want to send, then Network.start() is called, and data is received from 
+		the same buffer inside the callback when it has all been transferred.
 
 		Read SyncSimple docs for a slightly more in-depth overview of this particular
 		peculiarity of WC3.
@@ -58,16 +45,15 @@ import StringEncoder
 					...
 
 			3. Specify a callback for when Network has finished it's operation and
-			all data is available for players to be read:
-				network.onFinish((buffer) -> begin
+			all data is available for players to be read, and start the transmission.
+			Status will be set to NetworkResult.ABORTED if the player left during
+			the transmission, or is not present:
+				network.start((status, buffer) -> begin
 					var int = buffer.readInt()
 					var real = buffer.readReal()
 					var string = buffer.readString()
 					...
 				end)
-
-			4. Start the transmission:
-				network.start()
 
 		Sending objects implementing BufferSerializable:
 			You may find yourself sending not simply raw data, but some
@@ -114,7 +100,7 @@ import StringEncoder
 					buffer.write(myClass)
 
 			3. Read instances of MyClass:
-				network.onFinish((buffer) -> begin
+				network.start((status, buffer) -> begin
 					let myClass = new MyClass(buffer)
 
 					doSomethingWithMyClass(myClass)
@@ -122,7 +108,7 @@ import StringEncoder
 
 				// or, without the constructor
 
-				network.onFinish((buffer) -> begin
+				network.start((status, buffer) -> begin
 					// get existing instance
 					let myClass = getOldMyClassInstance()
 
@@ -179,8 +165,8 @@ import StringEncoder
 		all the heavy lifting.
 
 		Before starting the transmission, the HashBuffer is locked into an immutable state, in
-		which incorrect mutation attempts will print warnings, so long as safety checks are not disabled.
-		The maximum amount of data across all primitive buffer is calculated, and the amount of 
+		which incorrect mutation attempts will print warnings, as long as safety checks are not disabled.
+		The maximum amount of data across all primitive buffers is calculated, and the amount of 
 		required 'sync rounds' is calculated - that is, the amount of times we need to flush/sync
 		data out of the gamecaches to keep key sizes short.
 
@@ -193,14 +179,30 @@ import StringEncoder
 		to stop, and start another sync round if necessary. If it is not necessary,
 		we open the HashBuffer for reading and call the finish callback, and destroy the instance.
 ********************************************************************************/
+package Network
+
+import public SyncSimple
+import ErrorHandling
+import public Execute
+import public Buffer
+
+import NetworkConfig
+import Metadata
+import GamecacheKeys
+import GamecacheBuffer
+import StringEncoder
 
 enum NetworkState
 	PREPARING
 	SENDING_ROUND
 	FINISHED
 
+public enum NetworkResult
+	SUCCESS
+	ABORTED
+
 interface NetworkFinishedCallback
-	function onFinish(HashBuffer buffer)
+	function onFinish(NetworkResult status, HashBuffer buffer)
 
 public class Network
 	// gamecache used for syncing integers, reals and booleans
@@ -239,7 +241,7 @@ public class Network
 	private var counters = EMPTY_META
 
 	// finish callback
-	private NetworkFinishedCallback finishCallback = (Buffer _buffer) -> error("Network: did not specify any callback function")
+	private NetworkFinishedCallback finishCallback = (NetworkResult _result, Buffer _buffer) -> error("Network: did not specify any callback function")
 
 	construct(player sender)
 		this.sender = sender
@@ -257,11 +259,22 @@ public class Network
 	function getData() returns HashBuffer
 		return dataBuffer
 
+	/** aborts the current transmission **/
+	private function abort()
+		currentState = NetworkState.FINISHED
+		finishCallback.onFinish(NetworkResult.ABORTED, dataBuffer)
+		destroy this
+
 	/** sends info about the amount of data to be expected to each player **/
 	private function sendMetadata()
 		// we should only send the metadata once
 		if SAFETY_CHECKS_ENABLED and currentState != NetworkState.PREPARING
 			error("Network: trying to send duplicate metadata")
+
+		// if the sender disconnected, we can't expect any valid data, so immediately return
+		if not sender.isIngame()
+			abort()
+			return
 
 		if localPlayer == sender
 			// push all strings into the string encoder
@@ -410,6 +423,10 @@ public class Network
 		if SAFETY_CHECKS_ENABLED and currentState != NetworkState.SENDING_ROUND
 			error("Network: trying to receive round at the wrong time")
 
+		if not sender.isIngame()
+			abort()
+			return
+
 		// metadata is sent with the first round, so read it first
 		if not metaReceived
 			receiveMetadata()
@@ -447,11 +464,10 @@ public class Network
 			dataBuffer.setMode(BufferMode.READ)
 			dataBuffer.resetRead()
 			currentState = NetworkState.FINISHED
-			finishCallback.onFinish(dataBuffer)
+			finishCallback.onFinish(NetworkResult.SUCCESS, dataBuffer)
 			destroy this
 
 	/** this is the function to start sending all data in the intermediate dataBuffer buffer, as well as specifying a callback **/
 	function start(NetworkFinishedCallback callback)
 		finishCallback = callback
 		sendMetadata()
-

--- a/wurst/network/SyncSimple.wurst
+++ b/wurst/network/SyncSimple.wurst
@@ -1,30 +1,9 @@
-package SyncSimple
-
-import UnitIndexer
-import BitSet
-import LinkedListModule
-import RegisterEvents
-import MapBounds
-import OnUnitEnterLeave
-import ClosureForGroups
-
-/**
-	Configure this function if you need to change how the dummy is created.
-	WARNING: The dummy must be selectable and not locusted, or else it will not work.
-**/
-@configurable
-function getDummy() returns unit
-	return createUnit(DUMMY_PLAYER, 'hfoo', boundMax, 0 .fromDeg())
-	..addAbility(GHOST_VIS_ID)
-	..pause()
-	..setScale(0)
-
 /********************************************************************************
 	SyncSimple library by MoriMori.
 
 	Based on TriggerHappy's SyncInteger library.
 
-	Rationale:
+	Overview:
 		This library can be used to send a 'synchronize' network event that will fire
 		for all players after all previous network events have also been received
 		by all players.
@@ -87,6 +66,26 @@ function getDummy() returns unit
 		To synchronize again, create a new SimpleSynchronizer
 			
 ********************************************************************************/
+package SyncSimple
+
+import UnitIndexer
+import BitSet
+import LinkedListModule
+import RegisterEvents
+import MapBounds
+import OnUnitEnterLeave
+import ClosureForGroups
+
+/**
+	Configure this function if you need to change how the dummy is created.
+	WARNING: The dummy must be selectable and not locusted, or else it will not work.
+**/
+@configurable
+function getDummy() returns unit
+	return createUnit(DUMMY_PLAYER, 'hfoo', boundMax, 0 .fromDeg())
+	..addAbility(GHOST_VIS_ID)
+	..pause()
+	..setScale(0)
 
 // briefly selects the specified unit by the player
 unit last = null


### PR DESCRIPTION
Changelog:
* Added ability to suppress error messages with the global `suppressErrorMessages` variable. This is used in the `Execute` package, in function `try` to facilitate a very basic form of exception-handling. Rationale: `Persistable` relies on the `deserialize` function to throw an error when a deserialization fails (tampered data, missing file, etc.), but since this is acceptable behaviour, and the error is properly handled upstream with `try`, there is no need for the player to see the inevitable error message. This shouldn't affect regular errors.
* Renamed `MultiIO` to `MultifileIO`, renamed `SimpleIO` to `PreloadIO`. Rationale: `PreloadIO` is meant to be a simple wrapper around the Preload API, and does no checks for Local Files. The reasoning is that there may be use cases where you want to use the Preload API without having to pull in the `LocalFiles` dependency, together with Network, which is a very heavy package, such as for simple logging or saving of other data, without reading it back.
* Added `LocalFiles` package providing functionality to detect 1.26 version and whether Local Files are enabled, and automatically syncs those results.
* Added Local Files checks to `MultifileIO` and `Persistable` during loading. Now all load callbacks return a mandatory status enum reflecting the status of the operation. Saving, however, works without Local Files anyway, so I don't enforce that check.
* Added 1.26 fallback support to `MultifileIO`, moving it outside of `PreloadIO`.
* Added disconnection detection to `Network`. Now the callback returns a status enum depending on whether or not the operation succeeded or not.
* Updated `Network`/`SyncSimple` global hot-docs to apply to the package, instead of enums inside them.
* Fixed various typos in docs and updated them to reflect latest changes.
* Added int/string to bool conversions.

