### PR TITLE
Add TargetsAllowed to prevent typos

### DIFF
--- a/wurst/objediting/TargetsAllowed.wurst
+++ b/wurst/objediting/TargetsAllowed.wurst
@@ -2,34 +2,65 @@ package TargetsAllowed
 import NoWurst
 
 public class TargetsAllowed
+	/** Can only target air units. */
 	static constant air          = "air"
+	/** Can only target alive units (non-skeleton). */
 	static constant alive        = "alive"
+	/** Can only target allied units, but not units on the same team as casting unit. */
 	static constant allies       = "allies"
+	/** Can only target ancients i.e only the night elf buildings that can uproot. */
 	static constant ancient      = "ancient"
+	/** Can only target dead units (corpses, skeletons). */
 	static constant dead         = "dead"
+	/** Can only target debris, e.g crates. */
 	static constant debris       = "debris"
+	/** TODO: unknown what this target allows. */
 	static constant decoration   = "decoration"
+	/** Can only target enemy units. */
 	static constant enemies      = "enemies"
+	/** Can only target allied and own units. */
 	static constant friend       = "friend"
+	/** Can only target units without flying/hover movement type. */
 	static constant ground       = "ground"
+	/** Can only target hero units. */
 	static constant hero         = "hero"
+	/** Can only target invulnerable targets. */
 	static constant invulnerable = "invulnerable"
+	/** Can only target items lying on the ground. */
 	static constant item_t       = "item" // Suffixed with _t to prevent collision with native type item
+	/** Can only target mechanichal units catapults etc. */
 	static constant mechanical   = "mechanical"
+	/** Can only target units which belong to neutral players (Neutral Hostile, Neutral Passive) */
 	static constant neutral      = "neutral"
+	/** Can only target non-ancient units. */
 	static constant nonancient   = "nonancient"
+	/** No targets allowed. */
 	static constant none         = "none"
+	/** Can only target non-heroes. */
 	static constant nonhero      = "nonhero"
+	/** Can only target non-suicidal units. */
 	static constant nonsapper    = "nonsapper"
+	/** Cannot target casting unit. */
 	static constant notself      = "notself"
+	/** Can only target non-mechanical units. */
 	static constant organic      = "organic"
+	/** TOOD: this is unknown what it does. */
 	static constant player_t     = "player" // Suffixed with _t to prevent collision with native type player
+	/** Only able to target units from the same player as casting unit. */
 	static constant playerunits  = "playerunits"
+	/** Can only target suicidal units such as Goblin Sapper. */
 	static constant sapper       = "sapper"
+	/** Can only target caster. */
 	static constant self         = "self"
+	/** Can target buildings. */
 	static constant structure    = "structure"
+	/** Can only target landscape such as grass, water or dirt. */
 	static constant terrain      = "terrain"
+	/** Can only target trees. */
 	static constant tree         = "tree"
+	/** Can only target units that can take damage. */
 	static constant vulnerable   = "vulnerable"
+	/** TODO: uncertain if this limits valid targets to gates. */
 	static constant wall         = "wall"
+	/** Limit to units which are wards (Statis Traps, etc). */
 	static constant ward         = "ward"

--- a/wurst/objediting/TargetsAllowed.wurst
+++ b/wurst/objediting/TargetsAllowed.wurst
@@ -1,0 +1,35 @@
+package TargetsAllowed
+import NoWurst
+
+public class TargetsAllowed
+	static constant air          = "air"
+	static constant alive        = "alive"
+	static constant allies       = "allies"
+	static constant ancient      = "ancient"
+	static constant dead         = "dead"
+	static constant debris       = "debris"
+	static constant decoration   = "decoration"
+	static constant enemies      = "enemies"
+	static constant friend       = "friend"
+	static constant ground       = "ground"
+	static constant hero         = "hero"
+	static constant invulnerable = "invulnerable"
+	static constant item_t       = "item" // Suffixed with _t to prevent collision with native type item
+	static constant mechanical   = "mechanical"
+	static constant neutral      = "neutral"
+	static constant nonancient   = "nonancient"
+	static constant none         = "none"
+	static constant nonhero      = "nonhero"
+	static constant nonsapper    = "nonsapper"
+	static constant notself      = "notself"
+	static constant organic      = "organic"
+	static constant player_t     = "player" // Suffixed with _t to prevent collision with native type player
+	static constant playerunits  = "playerunits"
+	static constant sapper       = "sapper"
+	static constant self         = "self"
+	static constant structure    = "structure"
+	static constant terrain      = "terrain"
+	static constant tree         = "tree"
+	static constant vulnerable   = "vulnerable"
+	static constant wall         = "wall"
+	static constant ward         = "ward"

--- a/wurst/objediting/UnitObjEditing.wurst
+++ b/wurst/objediting/UnitObjEditing.wurst
@@ -2,6 +2,7 @@ package UnitObjEditing
 import NoWurst
 
 import ObjEditingNatives
+import public TargetsAllowed
 
 public enum MovementType
 	None


### PR DESCRIPTION
Would also be really helpful if we could comment each value so it would be clearer what the differences is between `allies` and `friends` for example.

Any feedback on the choice of suffixing the values with `_t` to avoid the namespace collision?