### PR TITLE
Fix addAt function in LinkedList class

### DIFF
--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -215,8 +215,8 @@ public class LinkedList<T>
 
 	/** Adds the given element directly behind the element at the given index */
 	function addAt(T elem, int index)
-		let entry = new LLEntry<T>(elem, dummy.prev, dummy)
 		let entryAtIndex = getEntry(index)
+		let entry = new LLEntry<T>(elem, entryAtIndex.prev, entryAtIndex)
 		entryAtIndex.prev.next = entry
 		entryAtIndex.prev = entry
 		size++

--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -81,7 +81,7 @@ public class LinkedList<T>
 			removeEntry(top)
 		return result
 		
-	/** Returns and removes the lastly added Element */
+	/** Returns the lastly added Element */
 	function peek() returns T
 		return dummy.prev.elem
 	

--- a/wurst/data/LinkedListTests.wurst
+++ b/wurst/data/LinkedListTests.wurst
@@ -109,3 +109,13 @@ function testGenerics()
 		bi2++
 
 	bi2.assertEquals(list.size())
+
+@test function testAddAt()
+	let list = new LinkedList<int>()
+	for i = 1 to 6
+		list.add(i)
+	list.addAt(7, 4)
+	string elems = ""
+	for elem in list
+		elems += elem.toString()
+	elems.assertEquals("1234756")


### PR DESCRIPTION
Current `addAt` function is wrong because it creates the new `LLEntry`, that is connected with the `dummy`. I fixed it. Now the new `LLEntry` is correctly connected with the old `LLEntry` in the place of which it is inserted.
I mean `entry.next` and `entry.prev` relations