### PR TITLE
Item and Unit package improvements.

### DIFF
--- a/wurst/_handles/Item.wurst
+++ b/wurst/_handles/Item.wurst
@@ -8,62 +8,107 @@ public function createItem(int itemId, vec2 pos) returns item
 public function createItem(int itemId, vec3 pos) returns item
 	return CreateItem(itemId, pos.x, pos.y)
 
-public function item.getName() returns string
-	return GetItemName( this )
-	
-public function item.getX() returns real
-	return GetItemX( this )
-		
-public function item.getY() returns real
-	return GetItemY( this )
-
-public function item.setPos( real x, real y )
-	SetItemPosition( this, x, y )
-	
-public function item.setPos( vec2 pos )
-	SetItemPosition( this, pos.x, pos.y )
-	
-public function item.getPos() returns vec2
-	return vec2(this.getX(), this.getY())
-	
-public function item.getUserData() returns int
-	return GetItemUserData(this)
-	
-public function item.setUserData(int data)
-	SetItemUserData(this, data)
-	
 public function item.remove()
 	RemoveItem(this)
 
 public function item.getTypeId() returns int
 	return GetItemTypeId(this)
 
+public function item.getLevel() returns int
+	return GetItemLevel(this)
+
+public function item.getX() returns real
+	return GetItemX(this )
+
+public function item.getY() returns real
+	return GetItemY(this)
+
+public function item.getPos() returns vec2
+	return vec2(this.getX(), this.getY())
+
+public function item.setPos(real x, real y)
+	SetItemPosition(this, x, y)
+
+public function item.setPos(vec2 pos)
+	SetItemPosition(this, pos.x, pos.y)
+
+public function item.setDropOnDeath(boolean flag)
+	SetItemDropOnDeath(this, flag)
+
+public function item.setDroppable(boolean flag)
+	SetItemDroppable(this, flag)
+
+public function item.setPawnable(boolean flag)
+	SetItemPawnable(this, flag)
+
+public function item.setInvulnerable(boolean flag)
+	SetItemInvulnerable(this, flag)
+
 public function item.setVisible(boolean flag)
 	SetItemVisible(this, flag)
+
+public function item.isInvulnerable() returns boolean
+	return IsItemInvulnerable(this)
+
+public function item.isVisible() returns boolean
+	return IsItemVisible(this)
+
+public function item.isOwned() returns boolean
+	return IsItemOwned(this)
+
+public function item.isPowerup() returns boolean
+	return IsItemPowerup(this)
+
+public function item.isSellable() returns boolean
+	return IsItemSellable(this)
+
+public function item.isPawnable() returns boolean
+	return IsItemPawnable(this)
+
+public function item.getPlayer() returns player
+	return GetItemPlayer(this)
+
+public function item.setPlayer(player whichPlayer, boolean changeColor)
+	SetItemPlayer(this, whichPlayer, changeColor)
+
+public function item.getCharges() returns int
+	return GetItemCharges(this)
+
+public function item.setCharges(int charges)
+	SetItemCharges(this, charges)
+
+public function item.getUserData() returns int
+	return GetItemUserData(this)
+
+public function item.setUserData(int data)
+	SetItemUserData(this, data)
+
+public function item.getName() returns string
+	return GetItemName(this)
 
 public function item.setName(string name)
 	BlzSetItemName(this, name)
 
-public function item.setDescription(string description)
-	BlzSetItemDescription(this, description)
-
 public function item.getDescription() returns string
 	return BlzGetItemDescription(this)
 
-public function item.setTooltip(string tooltip)
-	BlzSetItemTooltip(this, tooltip)
+public function item.setDescription(string description)
+	BlzSetItemDescription(this, description)
 
 public function item.getTooptip() returns string
 	return BlzGetItemTooltip(this)
 
-public function item.setExtendedTooltip(string tooltip)
-	BlzSetItemExtendedTooltip(this, tooltip)
+public function item.setTooltip(string tooltip)
+	BlzSetItemTooltip(this, tooltip)
 
 public function item.getExtendedTooltip() returns string
 	return BlzGetItemExtendedTooltip(this)
 
-public function item.setIconPath(string path)
-	BlzSetItemIconPath(this, path)
+public function item.setExtendedTooltip(string tooltip)
+	BlzSetItemExtendedTooltip(this, tooltip)
 
 public function item.getIconPath() returns string
 	return BlzGetItemIconPath(this)
+
+public function item.setIconPath(string path)
+	BlzSetItemIconPath(this, path)

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -244,11 +244,11 @@ public function unit.itemInSlot(int inventoryIndex) returns item
 	return UnitItemInSlot(this, inventoryIndex)
 
 /** Retrieves slot number for speficied item or -1 if not found. */
-public function unit.itemSlot(item itm) returns int
+public function unit.getItemSlot(item whichItem) returns int
 	int result = -1
-	if this.hasItem(itm)
+	if this.hasItem(whichItem)
 		for slot = 0 to this.inventorySize() - 1
-			if this.itemInSlot(slot) == itm
+			if this.itemInSlot(slot) == whichItem
 				result = slot
 				break
 	return result

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -32,10 +32,14 @@ public function unit.addEffect(string fx, string attachment) returns effect
 public function unit.addHP(real val)
 	this.addState(UNIT_STATE_LIFE, val)
 
-public function unit.addItem(item whichItem) returns boolean
+public function unit.addItemHandle(item whichItem) returns boolean
 	return UnitAddItem(this, whichItem)
 
 public function unit.addItemById(int itemId) returns item
+	return UnitAddItemById(this, itemId)
+
+@deprecated("Use addItemById method instead.")
+public function unit.addItem(int itemId) returns item
 	return UnitAddItemById(this, itemId)
 
 public function unit.addItemToSlot(int id, int slot) returns bool
@@ -182,10 +186,12 @@ public function unit.hasItem(item whichItem) returns boolean
 	return UnitHasItem(this, whichItem)
 
 public function unit.hasItemById(int itemId) returns boolean
+	var hasItem = false
 	for slot = 0 to this.inventorySize() - 1
 		if this.itemInSlot(slot).getTypeId() == itemId
-			return true
-	return false
+			hasItem = true
+			break
+	return hasItem
 
 public function unit.hide()
 	ShowUnit(this, false)
@@ -196,7 +202,6 @@ public function unit.inventorySize() returns int
 /** Returns the number of items equipped. */
 public function unit.itemCount() returns int
 	int result = 0
-
 	for slot = 0 to this.inventorySize() - 1
 		if this.itemInSlot(slot) != null
 			result++
@@ -238,13 +243,15 @@ public function unit.issueTargetOrderById(int id, widget target) returns boolean
 public function unit.itemInSlot(int inventoryIndex) returns item
 	return UnitItemInSlot(this, inventoryIndex)
 
-/** Retrieves slot number for speficied item. */
+/** Retrieves slot number for speficied item or -1 if not found. */
 public function unit.itemSlot(item itm) returns int
+	int result = -1
 	if this.hasItem(itm)
 		for slot = 0 to this.inventorySize() - 1
 			if this.itemInSlot(slot) == itm
-				return slot
-	return -1
+				result = slot
+				break
+	return result
 
 public function unit.kill()
 	KillUnit(this)

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -32,8 +32,11 @@ public function unit.addEffect(string fx, string attachment) returns effect
 public function unit.addHP(real val)
 	this.addState(UNIT_STATE_LIFE, val)
 
-public function unit.addItem(int id) returns item
-	return UnitAddItemById(this, id)
+public function unit.addItem(item whichItem) returns boolean
+	return UnitAddItem(this, whichItem)
+
+public function unit.addItemById(int itemId) returns item
+	return UnitAddItemById(this, itemId)
 
 public function unit.addItemToSlot(int id, int slot) returns bool
 	return UnitAddItemToSlotById(this, id, slot)
@@ -179,18 +182,29 @@ public function unit.hasItem(item whichItem) returns boolean
 	return UnitHasItem(this, whichItem)
 
 public function unit.hasItemById(int itemId) returns boolean
-	var hasItem = false
-	for i = 0 to this.inventorySize() - 1
-		if this.itemInSlot(i).getTypeId() == itemId
-			hasItem = true
-			break
-	return hasItem
+	for slot = 0 to this.inventorySize() - 1
+		if this.itemInSlot(slot).getTypeId() == itemId
+			return true
+	return false
 
 public function unit.hide()
 	ShowUnit(this, false)
 
 public function unit.inventorySize() returns int
 	return UnitInventorySize(this)
+
+/** Returns the number of items equipped. */
+public function unit.itemCount() returns int
+	int result = 0
+
+	for slot = 0 to this.inventorySize() - 1
+		if this.itemInSlot(slot) != null
+			result++
+	return result
+
+/** Checks if unit inventory is full. */
+public function unit.isInventoryFull() returns boolean
+	return this.itemCount() == this.inventorySize()
 
 /** Checks if the unit is alive using the UnitAlive native */
 public function unit.isAlive() returns boolean
@@ -223,6 +237,14 @@ public function unit.issueTargetOrderById(int id, widget target) returns boolean
 
 public function unit.itemInSlot(int inventoryIndex) returns item
 	return UnitItemInSlot(this, inventoryIndex)
+
+/** Retrieves slot number for speficied item. */
+public function unit.itemSlot(item itm) returns int
+	if this.hasItem(itm)
+		for slot = 0 to this.inventorySize() - 1
+			if this.itemInSlot(slot) == itm
+				return slot
+	return -1
 
 public function unit.kill()
 	KillUnit(this)


### PR DESCRIPTION
Reorganized Item.wurst package:
- Getters before setters, if applicable. This is true also for natives
introduced in patch 1.29
- Natives added in patch 1.29 still remain on the botton, to match
common.j organization.
- Removed unnecessary white spaces

Unit.wurst package:
- Added itemCount extension method for returning unit's current item
count
- Added isInventoryFull extension method for checking if unit inventory
is full
- Added itemSlot extension method for retrieving slot number for
provided item
- Renamed addItem extension method to addItemById

Following natives have been accounted for:

native          GetItemPlayer   takes item whichItem returns player
native          SetItemDropOnDeath  takes item whichItem, boolean flag returns nothing
native          SetItemDroppable takes item i, boolean flag returns nothing
native          SetItemPawnable takes item i, boolean flag returns nothing
native          SetItemPlayer    takes item whichItem, player whichPlayer, boolean changeColor returns nothing
native          SetItemInvulnerable takes item whichItem, boolean flag returns nothing
native          IsItemInvulnerable  takes item whichItem returns boolean
native          SetItemVisible  takes item whichItem, boolean show returns nothing
native          IsItemVisible   takes item whichItem returns boolean
native          IsItemOwned     takes item whichItem returns boolean
native          IsItemPowerup   takes item whichItem returns boolean
native          IsItemSellable  takes item whichItem returns boolean
native          IsItemPawnable  takes item whichItem returns boolean
native          GetItemLevel    takes item whichItem returns integer
native          GetItemCharges  takes item whichItem returns integer
native          SetItemCharges  takes item whichItem, integer charges returns nothing

native          UnitAddItem             takes unit whichUnit, item whichItem returns boolean