### PR TITLE
Update Unit.wurst to include "remove item by ID"

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -280,11 +280,13 @@ public function unit.removeItem(item itm)
 /** Removes the first item of type itemId carried by the unit
 	returns true if an item was found and removed */
 public function unit.removeItemById(int itemId) returns boolean
+	boolean item_found = false
 	for slot = 0 to this.inventorySize()-1
 		if this.itemInSlot(slot).getTypeId() == itemId
 			this.removeItem(this.itemInSlot(slot))
-			return true
-	return false
+			item_found = true
+			break
+	return item_found
 
 public function unit.removeItemFromSlot(int slot) returns item
 	return UnitRemoveItemFromSlot(this, slot)

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -277,6 +277,12 @@ public function unit.removeAbility(int abil) returns boolean
 public function unit.removeItem(item itm)
 	UnitRemoveItem(this, itm)
 
+public function unit.removeItemById(int itemId)
+	for slot = 0 to this.inventorySize()-1
+		if this.itemInSlot(slot).getTypeId() == itemId
+			UnitRemoveItem(this, this.itemInSlot(slot))
+			break
+
 public function unit.removeItemFromSlot(int slot) returns item
 	return UnitRemoveItemFromSlot(this, slot)
 

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -277,11 +277,14 @@ public function unit.removeAbility(int abil) returns boolean
 public function unit.removeItem(item itm)
 	UnitRemoveItem(this, itm)
 
-public function unit.removeItemById(int itemId)
+/** Removes the first item of type itemId carried by the unit
+	returns true if an item was found and removed */
+public function unit.removeItemById(int itemId) returns boolean
 	for slot = 0 to this.inventorySize()-1
 		if this.itemInSlot(slot).getTypeId() == itemId
-			UnitRemoveItem(this, this.itemInSlot(slot))
-			break
+			this.removeItem(this.itemInSlot(slot))
+			return true
+	return false
 
 public function unit.removeItemFromSlot(int slot) returns item
 	return UnitRemoveItemFromSlot(this, slot)


### PR DESCRIPTION
Just added a simple function, unit.removeItemById. Functionality pretty much copied from unit.hasItemById(int itemId). Useful when a user wants to remove an item and doesn't care how many of it there are or where it sits.