### PR TITLE
Addition of missing and utility unit & item natives.

### DIFF
--- a/wurst/_handles/Item.wurst
+++ b/wurst/_handles/Item.wurst
@@ -65,9 +65,11 @@ public function item.isSellable() returns boolean
 public function item.isPawnable() returns boolean
 	return IsItemPawnable(this)
 
+/** Verifies whether item is not destroyed and has a valid type id. */
 public function item.isAlive() returns boolean
 	return this.getTypeId() != 0 and GetWidgetLife(this) > .405
 
+/** Verifies whether item can be picked up by a unit by validating its life and ownership status. */
 public function item.isPickupable() returns boolean
 	return this.isAlive() and not this.isOwned() and this.isVisible()
 

--- a/wurst/_handles/Item.wurst
+++ b/wurst/_handles/Item.wurst
@@ -65,6 +65,12 @@ public function item.isSellable() returns boolean
 public function item.isPawnable() returns boolean
 	return IsItemPawnable(this)
 
+public function item.isAlive() returns boolean
+	return this.getTypeId() != 0 and GetWidgetLife(this) > .405
+
+public function item.isPickupable() returns boolean
+	return this.isAlive() and not this.isOwned() and this.isVisible()
+
 public function item.getPlayer() returns player
 	return GetItemPlayer(this)
 

--- a/wurst/_handles/Item.wurst
+++ b/wurst/_handles/Item.wurst
@@ -65,11 +65,11 @@ public function item.isSellable() returns boolean
 public function item.isPawnable() returns boolean
 	return IsItemPawnable(this)
 
-/** Verifies whether item is not destroyed and has a valid type id. */
+/** Returns true if item is not destroyed and has a valid type id. */
 public function item.isAlive() returns boolean
 	return this.getTypeId() != 0 and GetWidgetLife(this) > .405
 
-/** Verifies whether item can be picked up by a unit by validating its life and ownership status. */
+/** Returns true if item can be picked up by a unit. */
 public function item.isPickupable() returns boolean
 	return this.isAlive() and not this.isOwned() and this.isVisible()
 

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -297,8 +297,8 @@ public function unit.removeItemById(int itemId) returns boolean
 public function unit.removeItemFromSlot(int slot) returns item
 	return UnitRemoveItemFromSlot(this, slot)
 
-public function unit.dropItemPoint(item itm, real x, real y) returns boolean
-	return UnitDropItemPoint(this, itm, x, y)
+public function unit.dropItemPoint(item itm, vec2 pos) returns boolean
+	return UnitDropItemPoint(this, itm, pos.x, pos.y)
 
 public function unit.dropItemSlot(item itm, int slot) returns boolean
 	return UnitDropItemSlot(this, itm, slot)
@@ -309,8 +309,8 @@ public function unit.dropItemTarget(item itm, widget target) returns boolean
 public function unit.useItem(item itm) returns boolean
 	return UnitUseItem(this, itm)
 
-public function unit.useItemPoint(item itm, real x, real y) returns boolean
-	return UnitUseItemPoint(this, itm, x, y)
+public function unit.useItemPoint(item itm, vec2 pos) returns boolean
+	return UnitUseItemPoint(this, itm, pos.x, pos.y)
 
 public function unit.useItemTarget(item itm, widget target) returns boolean
 	return UnitUseItemTarget(this, itm, target)

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -297,6 +297,24 @@ public function unit.removeItemById(int itemId) returns boolean
 public function unit.removeItemFromSlot(int slot) returns item
 	return UnitRemoveItemFromSlot(this, slot)
 
+public function unit.dropItemPoint(item itm, real x, real y) returns boolean
+	return UnitDropItemPoint(this, itm, x, y)
+
+public function unit.dropItemSlot(item itm, int slot) returns boolean
+	return UnitDropItemSlot(this, itm, slot)
+
+public function unit.dropItemTarget(item itm, widget target) returns boolean
+	return UnitDropItemTarget(this, itm, target)
+
+public function unit.useItem(item itm) returns boolean
+	return UnitUseItem(this, itm)
+
+public function unit.useItemPoint(item itm, real x, real y) returns boolean
+	return UnitUseItemPoint(this, itm, x, y)
+
+public function unit.useItemTarget(item itm, widget target) returns boolean
+	return UnitUseItemTarget(this, itm, target)
+
 public function unit.revive(vec2 pos, boolean doEyecandy)
 	ReviveHero(this, pos.x, pos.y, doEyecandy)
 


### PR DESCRIPTION
Following extension methods have been defined:

- public function unit.dropItemPoint(item itm, real x, real y) returns boolean
- public function unit.dropItemSlot(item itm, int slot) returns boolean
- public function unit.dropItemTarget(item itm, widget target) returns boolean
- public function unit.useItem(item itm) returns boolean
- public function unit.useItemPoint(item itm, real x, real y) returns boolean
- public function unit.useItemTarget(item itm, widget target) returns boolean

- public function item.isAlive() returns boolean
- public function item.isPickupable() returns boolean