### PR TITLE
Add missing extension functions + prop window fix

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -170,9 +170,11 @@ public function unit.getPos3Zero() returns vec3
 public function unit.getPos3with(real z) returns vec3
 	return vec3(this.getX(), this.getY(), z)
 
+/** Returns the prop window of the unit in radians.*/
 public function unit.getPropWindow() returns real
 	return GetUnitPropWindow(this)
 
+/** Returns the prop window of the unit as angle.*/
 public function unit.getPropWindowAngle() returns angle
 	return angle(GetUnitPropWindow(this))
 
@@ -367,8 +369,8 @@ public function unit.setPos(real x, real y)
 
 /**	A prop window of 0 prevents the unit from moving, but
 	it can still turn around.*/
-public function unit.setPropWindow(real value)
-	SetUnitPropWindow(this, value)
+public function unit.setPropWindow(real radians)
+	SetUnitPropWindow(this, radians)
 	
 /**	A prop window of 0 prevents the unit from moving, but
 	it can still turn around.*/
@@ -461,10 +463,11 @@ public function unit.resetAbilityCooldown(int abilId)
 public function unit.getDefaultMovespeed() returns real
 	return GetUnitDefaultMoveSpeed(this)
 
-//the native function GetUnitDefaultPropWindow() returns the value in degrees
+/** Returns the default prop window of the unit in degrees.*/
 public function unit.getDefaultPropWindow() returns real
-	return GetUnitDefaultPropWindow(this) * bj_DEGTORAD
+	return GetUnitDefaultPropWindow(this)
 
+/** Returns the default prop window of the unit as angle.*/
 public function unit.getDefaultPropWindowAngle() returns angle
 	return GetUnitDefaultPropWindow(this).fromDeg()
 

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -108,6 +108,9 @@ public function unit.damageTarget(unit target, real amount, attacktype attacktyp
 public function unit.getAbilityLevel(int id) returns int
 	return GetUnitAbilityLevel(this, id)
 
+public function unit.getUnitAcquireRange() returns real
+	return GetUnitAcquireRange(this)
+
 /** Returns the current order of the unit */
 public function unit.getCurrentOrder() returns int
 	return GetUnitCurrentOrder(this)
@@ -167,8 +170,17 @@ public function unit.getPos3Zero() returns vec3
 public function unit.getPos3with(real z) returns vec3
 	return vec3(this.getX(), this.getY(), z)
 
+public function unit.getPropWindow() returns real
+	return GetUnitPropWindow(this)
+
+public function unit.getPropWindowAngle() returns angle
+	return angle(GetUnitPropWindow(this))
+
 public function unit.getState(unitstate state) returns real
 	return GetUnitState(this, state)
+
+public function unit.getTurnSpeed() returns real
+	return GetUnitTurnSpeed(this)
 
 public function unit.getTypeId() returns int
 	return GetUnitTypeId(this)
@@ -353,8 +365,15 @@ public function unit.setPosReal(vec3 pos)
 public function unit.setPos(real x, real y)
 	SetUnitPosition(this, x, y)
 
+/**	A prop window of 0 prevents the unit from moving, but
+	it can still turn around.*/
 public function unit.setPropWindow(real value)
 	SetUnitPropWindow(this, value)
+	
+/**	A prop window of 0 prevents the unit from moving, but
+	it can still turn around.*/
+public function unit.setPropWindow(angle value)
+	SetUnitPropWindow(this, value.radians())
 
 public function unit.setScale(real scale)
 	SetUnitScale(this, scale, scale, scale)
@@ -442,13 +461,17 @@ public function unit.resetAbilityCooldown(int abilId)
 public function unit.getDefaultMovespeed() returns real
 	return GetUnitDefaultMoveSpeed(this)
 
+//the native function GetUnitDefaultPropWindow() returns the value in degrees
 public function unit.getDefaultPropWindow() returns real
-	return GetUnitDefaultPropWindow(this)
+	return GetUnitDefaultPropWindow(this) * bj_DEGTORAD
+
+public function unit.getDefaultPropWindowAngle() returns angle
+	return GetUnitDefaultPropWindow(this).fromDeg()
 
 public function unit.getDefaultTurnSpeed() returns real
 	return GetUnitDefaultTurnSpeed(this)
 
-public function unit.getDefaultAquireRange() returns real
+public function unit.getDefaultAcquireRange() returns real
 	return GetUnitDefaultAcquireRange(this)
 
 public function unit.getDefaultFlyHeight() returns real

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -115,9 +115,7 @@ public function unit.getUnitAcquireRange() returns real
 public function unit.getCurrentOrder() returns int
 	return GetUnitCurrentOrder(this)
 
-/** Returns the unit's facing in degrees.
-	!Use .getFacingAngle() instead. */
-public function unit.getFacing() returns real
+@deprecated("Use .getFacingAngle() instead.") public function unit.getFacing() returns real
 	return GetUnitFacing(this)
 
 /** Returns the facing of the unit as an angle.
@@ -170,12 +168,8 @@ public function unit.getPos3Zero() returns vec3
 public function unit.getPos3with(real z) returns vec3
 	return vec3(this.getX(), this.getY(), z)
 
-/** Returns the prop window of the unit in radians.*/
-public function unit.getPropWindow() returns real
-	return GetUnitPropWindow(this)
-
 /** Returns the prop window of the unit as angle.*/
-public function unit.getPropWindowAngle() returns angle
+public function unit.getPropWindow() returns angle
 	return angle(GetUnitPropWindow(this))
 
 public function unit.getState(unitstate state) returns real
@@ -367,9 +361,7 @@ public function unit.setPosReal(vec3 pos)
 public function unit.setPos(real x, real y)
 	SetUnitPosition(this, x, y)
 
-/**	A prop window of 0 prevents the unit from moving, but
-	it can still turn around.*/
-public function unit.setPropWindow(real radians)
+@deprecated("Use .setPropWindow(angle value) instead.") public function unit.setPropWindow(real radians)
 	SetUnitPropWindow(this, radians)
 	
 /**	A prop window of 0 prevents the unit from moving, but
@@ -463,12 +455,8 @@ public function unit.resetAbilityCooldown(int abilId)
 public function unit.getDefaultMovespeed() returns real
 	return GetUnitDefaultMoveSpeed(this)
 
-/** Returns the default prop window of the unit in degrees.*/
-public function unit.getDefaultPropWindow() returns real
-	return GetUnitDefaultPropWindow(this)
-
 /** Returns the default prop window of the unit as angle.*/
-public function unit.getDefaultPropWindowAngle() returns angle
+public function unit.getDefaultPropWindow() returns angle
 	return GetUnitDefaultPropWindow(this).fromDeg()
 
 public function unit.getDefaultTurnSpeed() returns real
@@ -488,10 +476,13 @@ public function unit.setMaxHP(int hp)
 
 /** Changes a unit's maximum hp, adjusting the
 	current hp to keep the same ratio.*/
-public function unit.setMaxHPKeepRatio(int hp)
-	let ratio = this.getHP()/this.getMaxHP()
-	BlzSetUnitMaxHP(this, hp)
-	this.setHP(ratio * hp)	
+public function unit.setMaxHP(int hp, boolean keepRatio)
+	if keepRatio
+		let ratio = this.getHP()/this.getMaxHP()
+		BlzSetUnitMaxHP(this, hp)
+		this.setHP(ratio * hp)	
+	else
+		BlzSetUnitMaxHP(this, hp)
 
 public function unit.getIntMaxMana() returns int
 	return BlzGetUnitMaxMana(this)
@@ -501,10 +492,13 @@ public function unit.setMaxMana(int mana)
 
 /** Changes a unit's maximum mana, adjusting the
 	current mana to keep the same ratio.*/
-public function unit.setMaxManaKeepRatio(int mana)
-	let ratio = this.getMana()/this.getMaxMana()
-	BlzSetUnitMaxMana(this, mana)
-	this.setMana(ratio * mana)	
+public function unit.setMaxMana(int mana, boolean keepRatio)
+	if keepRatio
+		let ratio = this.getMana()/this.getMaxMana()
+		BlzSetUnitMaxMana(this, mana)
+		this.setMana(ratio * mana)	
+	else
+		BlzSetUnitMaxMana(this, mana)
 
 public function unit.deleteAbility(int abilCode)
 	BlzDeleteHeroAbility(this, abilCode)

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -486,11 +486,25 @@ public function unit.getIntMaxHP() returns int
 public function unit.setMaxHP(int hp)
 	BlzSetUnitMaxHP(this, hp)
 
+/** Changes a unit's maximum hp, adjusting the
+	current hp to keep the same ratio.*/
+public function unit.setMaxHPKeepRatio(int hp)
+	let ratio = this.getHP()/this.getMaxHP()
+	BlzSetUnitMaxHP(this, hp)
+	this.setHP(ratio * hp)	
+
 public function unit.getIntMaxMana() returns int
 	return BlzGetUnitMaxMana(this)
 
 public function unit.setMaxMana(int mana)
 	BlzSetUnitMaxMana(this, mana)
+
+/** Changes a unit's maximum mana, adjusting the
+	current mana to keep the same ratio.*/
+public function unit.setMaxManaKeepRatio(int mana)
+	let ratio = this.getMana()/this.getMaxMana()
+	BlzSetUnitMaxMana(this, mana)
+	this.setMana(ratio * mana)	
 
 public function unit.deleteAbility(int abilCode)
 	BlzDeleteHeroAbility(this, abilCode)

--- a/wurst/dummy/Fx.wurst
+++ b/wurst/dummy/Fx.wurst
@@ -104,7 +104,7 @@ public class Fx
 		
 	/** Get the xy angle */
 	function getXYAngle() returns angle
-		return dummy.getFacing().asAngleDegrees()
+		return dummy.getFacingAngle()
  
 	/** Set the xy angle */
 	function setXYAngle(angle value)

--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -182,7 +182,7 @@ public class Knockback3
             knockback.u.setMoveSpeed(0.)
 
         if USE_PROP_WINDOW_MODIFIERS
-            knockback.u.setPropWindow(0.)
+            knockback.u.setPropWindow(angle(0.))
 
 
     private static bool hitDestructable


### PR DESCRIPTION
Added missing getCurrentValue functions for functions that already had getDefaultValue: PropWindow, TurnSpeed, AcquireRange

Added functions with angle as parameter/return value for prop window functions.
Fixed a problem with getDefaultPropWindow:
The native returns the value in degrees, so it has to be converted to radians first. Usually all natives use radians.

Typo: AcquireRange