### PR TITLE
Functions to work with triggeraction & triggercondition

### DIFF
--- a/wurst/_wurst/TypeCasting.wurst
+++ b/wurst/_wurst/TypeCasting.wurst
@@ -90,6 +90,20 @@ public function triggerFromIndex(int index) returns trigger
 
 public function triggerToIndex(trigger object) returns int
 	return object.getHandleId()
+	
+public function triggeractionFromIndex(int index) returns triggeraction
+	typecastdata.saveFogState(0,ConvertFogState(index))
+	return typecastdata.loadTriggerAction(0)
+
+public function triggeractionToIndex(triggeraction object) returns int
+	return object.getHandleId()
+	
+public function triggerconditionFromIndex(int index) returns triggercondition
+	typecastdata.saveFogState(0,ConvertFogState(index))
+	return typecastdata.loadTriggerCondition(0)
+
+public function triggerconditionToIndex(triggercondition object) returns int
+	return object.getHandleId()
 
 public function timerFromIndex(int index) returns timer
 	typecastdata.saveFogState(0,ConvertFogState(index))

--- a/wurst/data/Table.wurst
+++ b/wurst/data/Table.wurst
@@ -113,6 +113,18 @@ public class Table
 	
 	function saveTrigger(int parentKey, trigger value)
 		ht.saveTriggerHandle( this castTo int, parentKey, value)
+		
+	function loadTriggerAction(int parentKey) returns triggeraction
+		return ht.loadTriggerActionHandle( this castTo int, parentKey)
+	
+	function saveTriggerAction(int parentKey, triggeraction value)
+		ht.saveTriggerActionHandle( this castTo int, parentKey, value)
+		
+	function loadTriggerCondition(int parentKey) returns triggercondition
+		return ht.loadTriggerConditionHandle( this castTo int, parentKey)
+	
+	function saveTriggerCondition(int parentKey, triggercondition value)
+		ht.saveTriggerConditionHandle( this castTo int, parentKey, value)
 			
 	function loadTimer(int parentKey) returns timer
 		return ht.loadTimerHandle( this castTo int, parentKey)


### PR DESCRIPTION
These functions allow to use triggeraction & triggercondition in generics. It can be useful, e.g. if you manage triggers dynamically and want to remove actions and conditions to avoid leaks