### PR TITLE
Revert raising limit on preloader

### DIFF
--- a/wurst/file/PreloadIO.wurst
+++ b/wurst/file/PreloadIO.wurst
@@ -19,7 +19,7 @@ import StringUtils
 /** Maximum amount of packets per single readable file. */
 public constant PACKETS_PER_FILE = bj_MAX_PLAYER_SLOTS
 /** Maximum payload size of a single readable packet. */
-public constant MAX_PACKET_LENGTH = 512
+public constant MAX_PACKET_LENGTH = 223
 
 /**
 	Low-level static writer wrapper around the Preload API


### PR DESCRIPTION
Contrary to my tests, WC3 can't read more than 223 characters from a player name, which broke the file IO. Reverting this to it's original value.