### PR TITLE
Update LinkedList.wurst raises warnings

### DIFF
--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -1,6 +1,6 @@
 package LinkedList
 import NoWurst
-import TypeCasting
+import public TypeCasting
 import Integer
 import String
 import ClosureForGroups


### PR DESCRIPTION
Cannot use `LinkedList` with handles by itself
![screenshot_4](https://user-images.githubusercontent.com/19322847/46083294-31e17a00-c1b2-11e8-97c6-e9a84c436723.png)
It requires to import `TypeCasting` package but then we get warnings
![screenshot_5](https://user-images.githubusercontent.com/19322847/46083351-50477580-c1b2-11e8-9a0a-114244be2858.png)
Can be resolved through public import of `TypeCasting` withing `LinkedList`.