### PR TITLE
Add vec.isInPolygon

### DIFF
--- a/wurst/math/Vectors.wurst
+++ b/wurst/math/Vectors.wurst
@@ -183,10 +183,37 @@ public function vec2.distanceToSegmentSq(vec2 v1, vec2 v2) returns real
 
 /** Checks whether the point is in a triangle defined by 3 points. */
 public function vec2.isInTriangle(vec2 p1, vec2 p2, vec2 p3) returns bool
-	let a = this.x * (p1.y - p2.y) + this.y * (p2.x - p1.x) + (p1.x * p2.y - p2.x * p1.y)
-	let b = this.x * (p2.y - p3.y) + this.y * (p3.x - p2.x) + (p2.x * p3.y - p3.x * p2.y)
-	let c = this.x * (p3.y - p1.y) + this.y * (p1.x - p3.x) + (p3.x * p1.y - p1.x * p3.y)
+	let a = (p2.x - p1.x) * (this.y - p1.y) - (this.x - p1.x) * (p2.y - p1.y)
+	let b = (p3.x - p2.x) * (this.y - p2.y) - (this.x - p2.x) * (p3.y - p2.y)
+	let c = (p1.x - p3.x) * (this.y - p3.y) - (this.x - p3.x) * (p1.y - p3.y)
 	return (a <= 0 and b <= 0 and c <= 0) or (a >= 0 and b >= 0 and c >= 0)
+
+/** Checks whether the point is in a polygon defined by a sequence of connected points. */
+public function vec2.isInPolygon(vararg vec2 args) returns bool
+	var result = false
+	vec2 array points
+	var count = 0
+	for arg in args
+		points[count] = arg
+		count++
+	points[count] = points[0]
+	if count == 3
+		result = this.isInTriangle(points[0], points[1], points[2])
+	else if count > 3
+		/* Winding number test. Simplified by quadrant checking. */
+		var test = 0
+		for i = 0 to count - 1
+			let p1 = points[i]
+			let p2 = points[i+1]
+			let side = (p2.x - p1.x) * (this.y - p1.y) - (this.x - p1.x) * (p2.y - p1.y)
+			if this.y >= p1.y
+				if this.y < p2.y and side >= 0
+					test++
+			else if this.y >= p2.y
+				if side <= 0
+					test--
+		result = test != 0
+	return result
 	
   /////////////////////////////////////////////////////////////////////////////////////////////
  //////////////////////////////////// 3D vector //////////////////////////////////////////////
@@ -406,6 +433,34 @@ Works as for vec2.isInTriangle, Z-coords are discarded. */
 @inline public function vec3.isInTriangle2d(vec3 p1, vec3 p2, vec3 p3) returns bool
 	return this.toVec2().isInTriangle(p1.toVec2(), p2.toVec2(), p3.toVec2())
 
+/** Checks whether the point is in a 2d polygon defined by a sequence of connected points.
+Works as for vec2.isInPolygon, Z-coords are discarded. */
+public function vec3.isInPolygon2d(vararg vec3 args) returns bool
+	var result = false
+	vec3 array points
+	var count = 0
+	for arg in args
+		points[count] = arg
+		count++
+	points[count] = points[0]
+	if count == 3
+		result = this.isInTriangle2d(points[0], points[1], points[2])
+	else if count > 3
+		/* Winding number test. Simplified by quadrant checking. */
+		var test = 0
+		for i = 0 to count - 1
+			let p1 = points[i]
+			let p2 = points[i+1]
+			let side = (p2.x - p1.x) * (this.y - p1.y) - (this.x - p1.x) * (p2.y - p1.y)
+			if this.y >= p1.y
+				if this.y < p2.y and side >= 0
+					test++
+			else if this.y >= p2.y
+				if side <= 0
+					test--
+		result = test != 0
+	return result
+
 @Test
 function vectorTests()
 	let v1 = vec2(1,2)
@@ -426,3 +481,16 @@ function vectorTests()
 	point3d.isInTriangle2d(vec3(9, 8, 23), vec3(3, 5, 0), vec3(4, 6, 15)).assertFalse()
 	point3d.isInTriangle2d(vec3(10, 15, -124), vec3(3, 5, 0), vec3(4, 6, -16)).assertTrue()
 	point3d.isInTriangle2d(vec3(48, 45, 85), vec3(-35, 0, 11), vec3(46, -6, 22)).assertTrue()
+
+@Test function testIsInPolygon()
+	let test1 = vec2(1, 3)
+	let test2 = vec2(-4, -6)
+	let test3 = vec2(-2, 2)
+	let points = [vec2(-3, -6), vec2(4, 5), vec2(-4, 5), vec2(3, -2)]
+	test1.isInPolygon(points[0], points[1], points[2], points[3]).assertTrue()
+	test2.isInPolygon(points[0], points[1], points[2], points[3]).assertFalse()
+	test3.isInPolygon(points[0], points[1], points[2]).assertTrue()
+	test1.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertTrue()
+	test2.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertFalse()
+	test3.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3()).assertTrue()
+


### PR DESCRIPTION
Redused calcs in `vec2.isInTriangle` 
I wouldn't like to copy the code from `vec2.isInPolygon` into `vec3.isInPolygon2d`.