### PR TITLE
Update Interpolation.wurst

### DIFF
--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -14,16 +14,16 @@ public function linear(real start, real stop, real p) returns real
 	return start + (stop - start) * p
 
 public function vec3.bezier3(vec3 mid, vec3 stop, real p) returns vec3
-	return vec3(bezier_3(this.x, mid.x, stop.x, p), bezier_3(this.y, mid.y, stop.y, p), bezier_3(this.z, mid.z, stop.z, p))
+	return vec3(bezier3(this.x, mid.x, stop.x, p), bezier3(this.y, mid.y, stop.y, p), bezier3(this.z, mid.z, stop.z, p))
 
 public function vec2.bezier3(vec2 mid, vec2 stop, real p) returns vec2
-	return vec2(bezier_3(this.x, mid.x, stop.x, p), bezier_3(this.y, mid.y, stop.y, p))
+	return vec2(bezier3(this.x, mid.x, stop.x, p), bezier3(this.y, mid.y, stop.y, p))
 	
 public function vec3.bezier4(vec3 mid1, vec3 mid2, vec3 stop, real p) returns vec3
-	return vec3(bezier_4(this.x, mid1.x, mid2.x, stop.x, p), bezier_4(this.y, mid1.y, mid2.y, stop.y, p), bezier_4(this.z, mid1.z, mid2.z, stop.z, p))
+	return vec3(bezier4(this.x, mid1.x, mid2.x, stop.x, p), bezier4(this.y, mid1.y, mid2.y, stop.y, p), bezier4(this.z, mid1.z, mid2.z, stop.z, p))
 
 public function vec2.bezier4(vec2 mid1, vec2 mid2, vec2 stop, real p) returns vec2
-	return vec2(bezier_4(this.x, mid1.x, mid2.x, stop.x, p), bezier_4(this.y, mid1.y, mid2.y, stop.y, p))
+	return vec2(bezier4(this.x, mid1.x, mid2.x, stop.x, p), bezier4(this.y, mid1.y, mid2.y, stop.y, p))
 
 public function vec3.lerp(vec3 target, real alpha) returns vec3
 	return vec3(this.x.lerp(target.x, alpha), this.y.lerp(target.y, alpha), this.z.lerp(target.z, alpha))
@@ -34,38 +34,50 @@ public function vec2.lerp(vec2 target, real alpha) returns vec2
 /**
 	3-Point-Bezier Interpolation
 	Sample Usage:
-	AddSpecialEffect(TEST_SFX,bezier_3(P1X,P3X,P2X,p),bezier_3(P1Y,P3Y,P2Y,p))
+	AddSpecialEffect(TEST_SFX,bezier3(P1X,P3X,P2X,p),bezier3(P1Y,P3Y,P2Y,p))
 */
+public function bezier3(real start, real mid, real stop, real p) returns real
+	return start + 2. * (mid - start) * p + (stop - 2. * mid + start) * p * p
+
+@deprecated("Use bezier3 instead.")
 public function bezier_3(real start, real mid, real stop, real p) returns real
-	return start + 2. * (mid - start) * p + (stop -2. * mid + start) * p * p
+	return bezier3(start, mid, stop, p) 
 
 /**
 	This function returns the derivate of the 3-Point-Bezier curve on certain point.
-	(d(bezier_3())/dt)
+	(d(bezier3())/dt)
 */
-public function derivBezier_3(real start, real mid, real stop, real p) returns real
+public function derivBezier3(real start, real mid, real stop, real p) returns real
 	return 2. * (mid - start) + 2. * (stop - 2. * mid + start) * p
+
+@deprecated("Use derivBezier3 instead.")
+public function derivBezier_3(real start, real mid, real stop, real p) returns real
+	return derivBezier3(start, mid, stop, p) 
 
 
 /**
 	4-Point-Bezier Interpolation
 	Sample Usage:
-	AddSpecialEffect(TEST_SFX,bezier_4(P1X,P3X,P4X,P2X,t),bezier_4(P1Y,P3Y,P4Y,P2Y,t))
+	AddSpecialEffect(TEST_SFX,bezier4(P1X,P3X,P4X,P2X,t),bezier4(P1Y,P3Y,P4Y,P2Y,t))
 */
-public function bezier_4(real start, real mid1, real mid2, real stop, real p) returns real
+public function bezier4(real start, real mid1, real mid2, real stop, real p) returns real
 	real m = p * p
 	return start + 3. * p * (mid1 - start) + 3. * m * (mid2 - 2. * mid1 + start) + m * p * (3. * (mid1 - mid2) + stop - start)
 
 /**
 	This function returns the derivate of the 4-Point-Bezier curve on certain point.
-	(d(bezier_4())/dt)
+	(d(bezier4())/dt)
 */
-public function derivBezier_4(real start, real mid1, real mid2, real stop, real p) returns real
+public function derivBezier4(real start, real mid1, real mid2, real stop, real p) returns real
 	return 3. * (mid1 - start) + 6. * (mid2 - 2. * mid1 + start) * p + 3. * (3. * (mid1 - mid2) + stop - start) * p * p
+
+@deprecated("Use derivBezier4 instead.")
+public function derivBezier_4(real start, real mid1, real mid2, real stop, real p) returns real
+	return derivBezier4(start, mid1, mid2, stop, p)
 
 
 //You can use Bezier 3 to graphic perfect parabolas
-//Bezier_4(<Start Point>, <OutTan_of_StartPoint>, <InTan_of_EndPoint>, <EndPoint>)
+//bezier4(<Start Point>, <OutTan_of_StartPoint>, <InTan_of_EndPoint>, <EndPoint>)
 
 /**	Hermite Interpolation */
 public function hermite(real start, real stop, real tangent1, real tangent2, real s) returns real

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -4,7 +4,7 @@ import Vectors
 import Wurstunit
 
 // Credits to BlinkyBoy
-/**Look at linear*/
+/** Look at linear */
 public function linear(vec2 start, vec2 stop, real p) returns vec2
 	return vec2(linear(start.x, stop.x, p), linear(start.y, stop.y, p))
 
@@ -89,10 +89,10 @@ public function vec3.derivBezier4(vec3 mid1, vec3 mid2, vec3 stop, real p) retur
 public function vec2.derivBezier4(vec2 mid1, vec2 mid2, vec2 stop, real p) returns vec2
 	return vec2(derivBezier4(this.x, mid1.x, mid2.x, stop.x, p), derivBezier4(this.y, mid1.y, mid2.y, stop.y, p))
 
-//You can use Bezier 3 to graphic perfect parabolas
-//bezier4(<Start Point>, <OutTan_of_StartPoint>, <InTan_of_EndPoint>, <EndPoint>)
+// You can use Bezier 3 to graphic perfect parabolas
+// bezier4(<Start Point>, <OutTan_of_StartPoint>, <InTan_of_EndPoint>, <EndPoint>)
 
-/**	Hermite Interpolation */
+/** Hermite Interpolation */
 public function hermite(real start, real stop, real tangent1, real tangent2, real s) returns real
 	real s2 = s * s
 	real h1 = 8.0 * s * s2 - 9.0 * s2

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -57,6 +57,11 @@ public function derivBezier3(real start, real mid, real stop, real p) returns re
 public function derivBezier_3(real start, real mid, real stop, real p) returns real
 	return derivBezier3(start, mid, stop, p) 
 
+public function vec3.derivBezier3(vec3 mid, vec3 stop, real p) returns vec3
+	return vec3(derivBezier3(this.x, mid.x, stop.x, p), derivBezier3(this.y, mid.y, stop.y, p), derivBezier3(this.z, mid.z, stop.z, p))
+
+public function vec2.derivBezier3(vec2 mid, vec2 stop, real p) returns vec2
+	return vec2(derivBezier3(this.x, mid.x, stop.x, p), derivBezier3(this.y, mid.y, stop.y, p))
 
 /**
 	4-Point-Bezier Interpolation
@@ -78,6 +83,11 @@ public function derivBezier4(real start, real mid1, real mid2, real stop, real p
 public function derivBezier_4(real start, real mid1, real mid2, real stop, real p) returns real
 	return derivBezier4(start, mid1, mid2, stop, p)
 
+public function vec3.derivBezier4(vec3 mid1, vec3 mid2, vec3 stop, real p) returns vec3
+	return vec3(derivBezier4(this.x, mid1.x, mid2.x, stop.x, p), derivBezier4(this.y, mid1.y, mid2.y, stop.y, p), derivBezier4(this.z, mid1.z, mid2.z, stop.z, p))
+
+public function vec2.derivBezier4(vec2 mid1, vec2 mid2, vec2 stop, real p) returns vec2
+	return vec2(derivBezier4(this.x, mid1.x, mid2.x, stop.x, p), derivBezier4(this.y, mid1.y, mid2.y, stop.y, p))
 
 //You can use Bezier 3 to graphic perfect parabolas
 //bezier4(<Start Point>, <OutTan_of_StartPoint>, <InTan_of_EndPoint>, <EndPoint>)
@@ -91,8 +101,6 @@ public function hermite(real start, real stop, real tangent1, real tangent2, rea
 	real h4 = s2 * (s - 1.0)
 	h1++
 	return h1 * start + h2 * stop + h3 * tangent1 + h4 * tangent2
-
-
 
 // TCB functions for finding the tangents among 3 points
 // Most modellers may know TCB from 3dsmax, in which they are used to make rotations
@@ -127,6 +135,14 @@ function linearVecTest()
 	start.bezier3(mid, stop, 0).assertEquals(start)
 	start.bezier3(mid, stop, 1).assertEquals(stop)
 
+@Test function testVec2DerivBezier3()
+	let start = vec2(-1, 0)
+	let mid = vec2(0, 2)
+	let stop = vec2(1, 0)
+	let p = 0.75
+	let expected = vec2(2, -2)
+	start.derivBezier3(mid, stop, p).assertEquals(expected)
+
 @Test function testVec2Bezier4()
 	let start = vec2(-3, 0)
 	let mid1 = vec2(-2, 2)
@@ -138,6 +154,15 @@ function linearVecTest()
 	start.bezier4(mid1, mid2, stop, 0).assertEquals(start)
 	start.bezier4(mid1, mid2, stop, 1).assertEquals(stop)
 
+@Test function testVec2DerivBezier4()
+	let start = vec2(-3, 0)
+	let mid1 = vec2(-2, 2)
+	let mid2 = vec2(0, 0)
+	let stop = vec2(1, 1)
+	let p = 0.75
+	let expected = vec2(4.125, -0.1875)
+	start.derivBezier4(mid1, mid2, stop, p).assertEquals(expected)
+
 @Test function testVec3Bezier3()
 	let start = vec3(-1, 0, -2)
 	let mid = vec3(0, 2, 0.5)
@@ -147,6 +172,14 @@ function linearVecTest()
 	start.bezier3(mid, stop, p).assertEquals(expected)
 	start.bezier3(mid, stop, 0).assertEquals(start)
 	start.bezier3(mid, stop, 1).assertEquals(stop)
+
+@Test function testVec3DerivBezier3()
+	let start = vec3(-1, 0, -2)
+	let mid = vec3(0, 2, 0.5)
+	let stop = vec3(1, 0, 3)
+	let p = 0.75
+	let expected = vec3(2, -2, 5)
+	start.derivBezier3(mid, stop, p).assertEquals(expected)
 
 @Test function testVec3Bezier4()
 	let start = vec3(-3, 0, 0)
@@ -158,3 +191,12 @@ function linearVecTest()
 	start.bezier4(mid1, mid2, stop, p).assertEquals(expected)
 	start.bezier4(mid1, mid2, stop, 0).assertEquals(start)
 	start.bezier4(mid1, mid2, stop, 1).assertEquals(stop)
+
+@Test function testVec3DerivBezier4()
+	let start = vec3(-3, 0, 0)
+	let mid1 = vec3(-2, 2, -3)
+	let mid2 = vec3(0, 0, 0)
+	let stop = vec3(1, 1, 2)
+	let p = 0.75
+	let expected = vec3(4.125, -0.1875, 6.1875)
+	start.derivBezier4(mid1, mid2, stop, p).assertEquals(expected)

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -1,4 +1,7 @@
 package Interpolation
+import NoWurst
+import Vectors
+import Wurstunit
 
 // Credits to BlinkyBoy
 /**Look at linear*/
@@ -34,7 +37,7 @@ public function vec2.lerp(vec2 target, real alpha) returns vec2
 /**
 	3-Point-Bezier Interpolation
 	Sample Usage:
-	AddSpecialEffect(TEST_SFX,bezier3(P1X,P3X,P2X,p),bezier3(P1Y,P3Y,P2Y,p))
+	AddSpecialEffect(TEST_SFX, bezier3(P1X, P3X, P2X, p), bezier3(P1Y, P3Y, P2Y, p))
 */
 public function bezier3(real start, real mid, real stop, real p) returns real
 	return start + 2. * (mid - start) * p + (stop - 2. * mid + start) * p * p
@@ -113,3 +116,46 @@ function linearVecTest()
 	let v = linear(vec2(3, 4), vec2(6, 2), 0.5)
 	v.x.assertEquals(4.5)
 	v.y.assertEquals(3)
+
+@Test function testVec2Vezier3()
+	let start = vec2(-1, 0)
+	let mid = vec2(0, 2)
+	let stop = vec2(1, 0)
+	let p = 0.75
+	let expected = vec2(0.5, 0.75)
+	start.bezier3(mid, stop, p).assertEquals(expected)
+	start.bezier3(mid, stop, 0).assertEquals(start)
+	start.bezier3(mid, stop, 1).assertEquals(stop)
+
+@Test function testVec2Bezier4()
+	let start = vec2(-3, 0)
+	let mid1 = vec2(-2, 2)
+	let mid2 = vec2(0, 0)
+	let stop = vec2(1, 1)
+	let p = 0.75
+	let expected = vec2(0.09375, 0.703125)
+	start.bezier4(mid1, mid2, stop, p).assertEquals(expected)
+	start.bezier4(mid1, mid2, stop, 0).assertEquals(start)
+	start.bezier4(mid1, mid2, stop, 1).assertEquals(stop)
+
+@Test function testVec3Bezier3()
+	let start = vec3(-1, 0, -2)
+	let mid = vec3(0, 2, 0.5)
+	let stop = vec3(1, 0, 3)
+	let p = 0.75
+	let expected = vec3(0.5, 0.75, 1.75)
+	start.bezier3(mid, stop, p).assertEquals(expected)
+	start.bezier3(mid, stop, 0).assertEquals(start)
+	start.bezier3(mid, stop, 1).assertEquals(stop)
+	
+
+@Test function testVec3Bezier4()
+	let start = vec3(-3, 0, 0)
+	let mid1 = vec3(-2, 2, -3)
+	let mid2 = vec3(0, 0, 0)
+	let stop = vec3(1, 1, 2)
+	let p = 0.75
+	let expected = vec3(0.09375, 0.703125, 0.421875)
+	start.bezier4(mid1, mid2, stop, p).assertEquals(expected)
+	start.bezier4(mid1, mid2, stop, 0).assertEquals(start)
+	start.bezier4(mid1, mid2, stop, 1).assertEquals(stop)

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -18,6 +18,12 @@ public function vec3.bezier3(vec3 mid, vec3 stop, real p) returns vec3
 
 public function vec2.bezier3(vec2 mid, vec2 stop, real p) returns vec2
 	return vec2(bezier_3(this.x, mid.x, stop.x, p), bezier_3(this.y, mid.y, stop.y, p))
+	
+public function vec3.bezier4(vec3 mid1, vec3 mid2, vec3 stop, real p) returns vec3
+	return vec3(bezier_4(this.x, mid1.x, mid2.x, stop.x, p), bezier_4(this.y, mid1.y, mid2.y, stop.y, p), bezier_4(this.z, mid1.z, mid2.z, stop.z, p))
+
+public function vec2.bezier4(vec2 mid1, vec2 mid2, vec2 stop, real p) returns vec2
+	return vec2(bezier_4(this.x, mid1.x, mid2.x, stop.x, p), bezier_4(this.y, mid1.y, mid2.y, stop.y, p))
 
 public function vec3.lerp(vec3 target, real alpha) returns vec3
 	return vec3(this.x.lerp(target.x, alpha), this.y.lerp(target.y, alpha), this.z.lerp(target.z, alpha))
@@ -46,7 +52,7 @@ public function derivBezier_3(real start, real mid, real stop, real p) returns r
 	Sample Usage:
 	AddSpecialEffect(TEST_SFX,bezier_4(P1X,P3X,P4X,P2X,t),bezier_4(P1Y,P3Y,P4Y,P2Y,t))
 */
-function bezier_4(real start, real mid1, real mid2, real stop, real p) returns real
+public function bezier_4(real start, real mid1, real mid2, real stop, real p) returns real
 	real m = p * p
 	return start + 3. * p * (mid1 - start) + 3. * m * (mid2 - 2. * mid1 + start) + m * p * (3. * (mid1 - mid2) + stop - start)
 

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -117,7 +117,7 @@ function linearVecTest()
 	v.x.assertEquals(4.5)
 	v.y.assertEquals(3)
 
-@Test function testVec2Vezier3()
+@Test function testVec2Bezier3()
 	let start = vec2(-1, 0)
 	let mid = vec2(0, 2)
 	let stop = vec2(1, 0)
@@ -147,7 +147,6 @@ function linearVecTest()
 	start.bezier3(mid, stop, p).assertEquals(expected)
 	start.bezier3(mid, stop, 0).assertEquals(start)
 	start.bezier3(mid, stop, 1).assertEquals(stop)
-	
 
 @Test function testVec3Bezier4()
 	let start = vec3(-3, 0, 0)


### PR DESCRIPTION
`bezier_4` function now public.
Added `bezier4` as extension functions for `vec3` and `vec2`.

Is there any hope that we can rename `bezier_4`  to `bezier4` and other underscores according to the convention?