### PR TITLE
Update StringUtils.wurst

### DIFF
--- a/wurst/util/StringUtils.wurst
+++ b/wurst/util/StringUtils.wurst
@@ -22,7 +22,7 @@ public function texttag.center(vec3 pos, string message, real size) returns text
 	while str.contains("|cff")
 		let idx = str.indexOf("|cff")
 		str = str.substring(0, idx) + str.substring(idx + 10, str.length())
-	this..setPos(pos - vec2(str.getWidth() / 1000. * bezier_3(3.0, 8.0, 11.5, size / 25)  * 6.5, 0))
+	this..setPos(pos - vec2(str.getWidth() / 1000. * bezier3(3.0, 8.0, 11.5, size / 25)  * 6.5, 0))
 	..setText(message, size)
 	return this
 


### PR DESCRIPTION
Prevent `bezier_3` warnings.