### PR TITLE
Update ClosureTimers.wurst

### DIFF
--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -61,7 +61,7 @@ public function doPeriodicallyTimed(real interval, real timerDuration, CallbackC
 
 //Timer Stuff
 public abstract class CallbackSingle
-	private timer t
+	private timer t = null
 	abstract function call()
 
 	function start(real time)
@@ -82,7 +82,7 @@ public abstract class CallbackSingle
 
 
 public abstract class CallbackPeriodic
-	private timer t
+	private timer t = null
 
 	protected abstract function call(thistype cb)
 
@@ -101,7 +101,7 @@ public abstract class CallbackPeriodic
 
 public abstract class CallbackCounted
 	private var count = 0
-	private timer t
+	private timer t = null
 
 	protected abstract function call(thistype cb)
 

--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -77,7 +77,8 @@ public abstract class CallbackSingle
 		destroy cb
 
 	ondestroy
-		t.release()
+		if t != null
+			t.release()
 
 
 public abstract class CallbackPeriodic
@@ -95,7 +96,8 @@ public abstract class CallbackPeriodic
 		cb.call(cb)
 
 	ondestroy
-		t.release()
+		if t != null
+			t.release()
 
 public abstract class CallbackCounted
 	private var count = 0
@@ -128,7 +130,8 @@ public abstract class CallbackCounted
 			destroy this
 
 	ondestroy
-		t.release()
+		if t != null
+			t.release()
 
 
 var x = 200


### PR DESCRIPTION
Currently I've got some trouble with these closures. Sometimes I need to destroy an early prepared closure callback before its starting that raises an error "Trying to release a null timer".

I'm unsure, can I do this if another PR is existing #143? I see a bit more problems which should be solved.