### PR TITLE
Add ClosureTimers functions as extension methods of `timer`

### DIFF
--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -6,20 +6,43 @@ import Wurstunit
 
 /** Execute an action after a certain time.
 	The callback object is automatically destroyed.
+	Must be used on a timer acquired with `getTimer()`
+
+	Example use:
+	| someTimer.doAfter(10.0) ->
+	|	 print("10 seconds later")
+*/
+public function timer.doAfter(real timeToWait, CallbackSingle cb) returns CallbackSingle
+	cb.start(this, timeToWait)
+	return cb
+
+/** Execute an action after a certain time.
+	The callback object is automatically destroyed.
 
 	Example use:
 	| doAfter(10.0) ->
 	|	 print("10 seconds later")
 */
 public function doAfter(real timeToWait, CallbackSingle cb) returns CallbackSingle
-	cb.start(timeToWait)
-	return cb
+	return getTimer().doAfter(timeToWait, cb)
 
 /** Execute an action with a 0-second timer delay.
 	The callback object is destroyed afterwards.
 */
 public function nullTimer(CallbackSingle cb) returns CallbackSingle
-	doAfter(0, cb)
+	return doAfter(0, cb)
+
+/** Execute an action periodically.
+	The callback has to be destroyed manually.
+	Must be used on a timer acquired with `getTimer()`
+
+	Example use:
+	| someTimer.doPeriodically(0.5) cb ->
+	|	 if i > 10
+			destroy cb
+*/
+public function timer.doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
+	cb.start(this, time)
 	return cb
 
 /** Execute an action periodically.
@@ -30,10 +53,20 @@ public function nullTimer(CallbackSingle cb) returns CallbackSingle
 	|	 if i > 10
 			destroy cb
 */
-
-
 public function doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
-	cb.start(time)
+	return getTimer().doPeriodically(time, cb)
+
+/** execute an action periodically, with a limited amount of calls
+	The callback object is destroyed after the action has been executed callAmount times.
+	Must be used on a timer acquired with `getTimer()`
+
+	Example use:
+	| someTimer.doPeriodicallyCounted(0.5, 100) cb ->
+	|	 doSomething()
+
+*/
+public function timer.doPeriodicallyCounted(real time, int callAmount, CallbackCounted cb) returns CallbackCounted
+	cb.start(this, time, callAmount)
 	return cb
 
 /** execute an action periodically, with a limited amount of calls
@@ -45,8 +78,20 @@ public function doPeriodically(real time, CallbackPeriodic cb) returns CallbackP
 
 */
 public function doPeriodicallyCounted(real time, int callAmount, CallbackCounted cb) returns CallbackCounted
-	cb.start(time, callAmount)
-	return cb
+	return getTimer().doPeriodicallyCounted(time, callAmount, cb)
+
+/** execute an action periodically, with a limited duration
+	The callback object is destroyed afterwards.
+	Must be used on a timer acquired with `getTimer()`
+
+	Example use:
+	| someTimer.doPeriodicallyCounted(0.5, 10.) ->
+	|	 doSomething()
+
+*/
+public function timer.doPeriodicallyTimed(real interval, real timerDuration, CallbackCounted cb) returns CallbackCounted
+	return this.doPeriodicallyCounted(interval, (timerDuration / interval + 0.5).toInt(), cb)
+
 /** execute an action periodically, with a limited duration
 	The callback object is destroyed afterwards.
 
@@ -56,16 +101,15 @@ public function doPeriodicallyCounted(real time, int callAmount, CallbackCounted
 
 */
 public function doPeriodicallyTimed(real interval, real timerDuration, CallbackCounted cb) returns CallbackCounted
-	doPeriodicallyCounted(interval, (timerDuration / interval + 0.5).toInt(), cb)
-	return cb
+	return getTimer().doPeriodicallyTimed(interval, timerDuration, cb)
 
 //Timer Stuff
 public abstract class CallbackSingle
 	private timer t
 	abstract function call()
 
-	function start(real time)
-		t = getTimer()
+	function start(timer whichTimer, real time)
+		t = whichTimer
 			..setData(this castTo int)
 			..start(time, () -> staticCallback())
 
@@ -85,10 +129,10 @@ public abstract class CallbackPeriodic
 
 	protected abstract function call(thistype cb)
 
-	function start(real time)
-		this.t = getTimer()
-		t.setData(this castTo int)
-		t.startPeriodic(time, function staticCallback)
+	function start(timer whichTimer, real time)
+		t = whichTimer
+			..setData(this castTo int)
+			..startPeriodic(time, function staticCallback)
 
 	private static function staticCallback()
 		let cb = (GetExpiredTimer().getData() castTo thistype)
@@ -103,11 +147,11 @@ public abstract class CallbackCounted
 
 	protected abstract function call(thistype cb)
 
-	function start(real time, int callAmount)
-		this.t = getTimer()
-		t.setData(this castTo int)
+	function start(timer whichTimer, real time, int callAmount)
 		count = callAmount
-		t.startPeriodic(time, function staticCallback)
+		t = whichTimer
+			..setData(this castTo int)
+			..startPeriodic(time, function staticCallback)
 
 	function isLast() returns boolean
 		return count == 1
@@ -143,4 +187,3 @@ var x = 200
 	doAfter(0.3) ->
 		x = x div 2
 		x.assertEquals(250)
-

--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -39,7 +39,7 @@ public function nullTimer(CallbackSingle cb) returns CallbackSingle
 	Example use:
 	| someTimer.doPeriodically(0.5) cb ->
 	|	 if i > 10
-			destroy cb
+	|		destroy cb
 */
 public function timer.doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
 	cb.start(this, time)
@@ -51,7 +51,7 @@ public function timer.doPeriodically(real time, CallbackPeriodic cb) returns Cal
 	Example use:
 	| doPeriodically(0.5) cb ->
 	|	 if i > 10
-			destroy cb
+	|		destroy cb
 */
 public function doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
 	return getTimer().doPeriodically(time, cb)


### PR DESCRIPTION
This allows for flexibility to use ClosurerTimers while keeping
a reference to the timer itself. This is especially important when
dealing with `timerdialog`.