### PR TITLE
Fixed deprecated UnitIndexer's getters

### DIFF
--- a/wurst/closures/ClosureEvents.wurst
+++ b/wurst/closures/ClosureEvents.wurst
@@ -277,8 +277,8 @@ public function unregisterEvents(int id)
 
 init
 	// Un/Register Events when unit enters map
-	onUnitIndex(() -> registerEventsForUnit(getIndexedUnit()))
-	onUnitDeindex(() -> unregisterEventsForUnit(getDeindexedUnit()))
+	onUnitIndex(() -> registerEventsForUnit(getIndexingUnit()))
+	onUnitDeindex(() -> unregisterEventsForUnit(getIndexingUnit()))
 
 	nullTimer() ->
 		unitTrig.addAction(() -> EventListener.generalEventCallback())

--- a/wurst/event/LastOrder.wurst
+++ b/wurst/event/LastOrder.wurst
@@ -145,4 +145,4 @@ init
 	registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SPELL_EFFECT, null, function spellActions)
 
 	onUnitDeindex() ->
-		getDeindexedUnit().clearLastOrders()
+		getIndexingUnit().clearLastOrders()


### PR DESCRIPTION
getIndexedUnit() -> getIndexingUnit()
getDeindexUnit() -> getIndexingUnit()