### PR TITLE
Allow access to unit associated with DummyCaster instance

### DIFF
--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -45,6 +45,8 @@ public class DummyCaster
 	function delay(real delay)
         this.delay = delay
 
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
+	*/
 	function castImmediate(int abilityId, int lvl, int orderId) returns unit
 		var dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
@@ -53,6 +55,8 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
+	*/
 	function castTarget(int abilityId, int lvl, int orderId, widget target) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
@@ -62,7 +66,8 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
-
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
+	*/
 	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -45,7 +45,7 @@ public class DummyCaster
 	function delay(real delay)
         this.delay = delay
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.*/
+	/** Returns the casting dummy unit if the cast order was successful, or null if cast failed.*/
 	function castImmediate(int abilityId, int lvl, int orderId) returns unit
 		var dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
@@ -54,7 +54,7 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed. */
+	/** Returns the casting dummy unit if the cast order was successful, or null if cast failed. */
 	function castTarget(int abilityId, int lvl, int orderId, widget target) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
@@ -64,7 +64,7 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed. */
+	/** Returns the casting dummy unit if the cast order was successful, or null if cast failed. */
 	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -29,7 +29,7 @@ public class DummyCaster
 	private var delay = 5.0
 	private var castCount = 0
 	private var origin = ZERO2
-    private var owner = DUMMY_PLAYER
+	private var owner = DUMMY_PLAYER
 
 	construct()
 
@@ -43,7 +43,7 @@ public class DummyCaster
 	/** Delay after which the dummy is recycled. Increase this if your spell is longer.
 		Default 5 seconds. */
 	function delay(real delay)
-        this.delay = delay
+		this.delay = delay
 
 	/** Returns the casting dummy unit if the cast order was successful, or null if cast failed.*/
 	function castImmediate(int abilityId, int lvl, int orderId) returns unit

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -46,36 +46,34 @@ public class DummyCaster
         this.delay = delay
 
 	function castImmediate(int abilityId, int lvl, int orderId) returns unit
-		let dummy = prepare(abilityId, lvl)
+		var dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
 		finish(dummy, abilityId)
-		if success
-			return dummy
-		else
-			return null
+		if not success
+			dummy = null
+		return dummy
 
 	function castTarget(int abilityId, int lvl, int orderId, widget target) returns unit
-		let dummy = prepare(abilityId, lvl)
+		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
 		let success = dummy.issueTargetOrderById(orderId, target)
 		finish(dummy, abilityId)
-		if success
-			return dummy
-		else
-			return null
+		if not success
+			dummy = null
+		return dummy
+
 
 	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns unit
-		let dummy = prepare(abilityId, lvl)
+		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))
 		let success = dummy.issuePointOrderById(orderId, targetPos)
 		finish(dummy, abilityId)
-		if success
-			return dummy
-		else
-			return null
+		if not success
+			dummy = null
+		return dummy
 
 	private function prepare(int id, int lvl) returns unit
-		let dummy = DummyRecycler.get(origin, angle(0))
+		var dummy = DummyRecycler.get(origin, angle(0))
 		if origin.inBounds()
 			dummy.setXY(origin)
 		dummy..addAbility(id)..setMana(1000000)

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -29,9 +29,15 @@ public class DummyCaster
 	private var delay = 5.0
 	private var castCount = 0
 	private var origin = ZERO2
-	private var owner = DUMMY_PLAYER
+    private var owner = DUMMY_PLAYER
+    private unit dummy = null
 
 	construct()
+
+	/** Returns the DummyCaster unit
+	*/
+    function getDummy() returns unit
+        return this.dummy
 
 	function origin(vec2 pos)
 		this.origin = pos
@@ -43,30 +49,30 @@ public class DummyCaster
 	/** Delay after which the dummy is recycled. Increase this if your spell is longer.
 		Default 5 seconds. */
 	function delay(real delay)
-		this.delay = delay
+        this.delay = delay
 
 	function castImmediate(int abilityId, int lvl, int orderId) returns boolean
-		let dummy = prepare(abilityId, lvl)
+		this.dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
 		finish(dummy, abilityId)
 		return success
 
 	function castTarget(int abilityId, int lvl, int orderId, widget target) returns boolean
-		let dummy = prepare(abilityId, lvl)
+		this.dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
 		let success = dummy.issueTargetOrderById(orderId, target)
 		finish(dummy, abilityId)
 		return success
 
 	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns boolean
-		let dummy = prepare(abilityId, lvl)
+		this.dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))
 		let success = dummy.issuePointOrderById(orderId, targetPos)
 		finish(dummy, abilityId)
 		return success
 
 	private function prepare(int id, int lvl) returns unit
-		let dummy = DummyRecycler.get(origin, angle(0))
+		this.dummy = DummyRecycler.get(origin, angle(0))
 		if origin.inBounds()
 			dummy.setXY(origin)
 		dummy..addAbility(id)..setMana(1000000)
@@ -83,4 +89,3 @@ public class DummyCaster
 			castCount--
 			if castCount == 0
 				destroy this
-

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -45,8 +45,7 @@ public class DummyCaster
 	function delay(real delay)
         this.delay = delay
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
-	*/
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.*/
 	function castImmediate(int abilityId, int lvl, int orderId) returns unit
 		var dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
@@ -55,8 +54,7 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
-	*/
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed. */
 	function castTarget(int abilityId, int lvl, int orderId, widget target) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
@@ -66,8 +64,7 @@ public class DummyCaster
 			dummy = null
 		return dummy
 
-	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed.
-	*/
+	/** Returns the casting dummy unit if cast order was succesful, or null if cast failed. */
 	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns unit
 		var dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -75,7 +75,7 @@ public class DummyCaster
 		return dummy
 
 	private function prepare(int id, int lvl) returns unit
-		var dummy = DummyRecycler.get(origin, angle(0))
+		let dummy = DummyRecycler.get(origin, angle(0))
 		if origin.inBounds()
 			dummy.setXY(origin)
 		dummy..addAbility(id)..setMana(1000000)

--- a/wurst/dummy/DummyCaster.wurst
+++ b/wurst/dummy/DummyCaster.wurst
@@ -30,14 +30,8 @@ public class DummyCaster
 	private var castCount = 0
 	private var origin = ZERO2
     private var owner = DUMMY_PLAYER
-    private unit dummy = null
 
 	construct()
-
-	/** Returns the DummyCaster unit
-	*/
-    function getDummy() returns unit
-        return this.dummy
 
 	function origin(vec2 pos)
 		this.origin = pos
@@ -51,28 +45,37 @@ public class DummyCaster
 	function delay(real delay)
         this.delay = delay
 
-	function castImmediate(int abilityId, int lvl, int orderId) returns boolean
-		this.dummy = prepare(abilityId, lvl)
+	function castImmediate(int abilityId, int lvl, int orderId) returns unit
+		let dummy = prepare(abilityId, lvl)
 		let success = dummy.issueImmediateOrderById(orderId)
 		finish(dummy, abilityId)
-		return success
+		if success
+			return dummy
+		else
+			return null
 
-	function castTarget(int abilityId, int lvl, int orderId, widget target) returns boolean
-		this.dummy = prepare(abilityId, lvl)
+	function castTarget(int abilityId, int lvl, int orderId, widget target) returns unit
+		let dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(target.getPos()))
 		let success = dummy.issueTargetOrderById(orderId, target)
 		finish(dummy, abilityId)
-		return success
+		if success
+			return dummy
+		else
+			return null
 
-	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns boolean
-		this.dummy = prepare(abilityId, lvl)
+	function castPoint(int abilityId, int lvl, int orderId, vec2 targetPos) returns unit
+		let dummy = prepare(abilityId, lvl)
 		dummy.setFacing(dummy.getPos().angleTo(targetPos))
 		let success = dummy.issuePointOrderById(orderId, targetPos)
 		finish(dummy, abilityId)
-		return success
+		if success
+			return dummy
+		else
+			return null
 
 	private function prepare(int id, int lvl) returns unit
-		this.dummy = DummyRecycler.get(origin, angle(0))
+		let dummy = DummyRecycler.get(origin, angle(0))
 		if origin.inBounds()
 			dummy.setXY(origin)
 		dummy..addAbility(id)..setMana(1000000)


### PR DESCRIPTION
Allow access to the unit associated with the DummyCaster instance.
For example I need this to bind a damage listener that detects when the casted spell actually hits the target.