### PR TITLE
Add linear probing to stringToIndex

### DIFF
--- a/wurst/_wurst/TypeCasting.wurst
+++ b/wurst/_wurst/TypeCasting.wurst
@@ -20,9 +20,15 @@ public function realFromIndex(int index) returns real
 	return (index / R2I_PRECISION)
 
 public function stringToIndex(string s) returns int
-	let hash = s.getHash()
-	if not typecastdata.hasString(hash)
-		typecastdata.saveString(hash, s)
+	var hash = s.getHash()
+	while true
+		if typecastdata.hasString(hash)
+			if typecastdata.loadString(hash) == s
+				break
+		else
+			typecastdata.saveString(hash, s)
+			break
+		hash++
 	return hash
 
 public function stringFromIndex(int index) returns string

--- a/wurst/data/LinkedListTests.wurst
+++ b/wurst/data/LinkedListTests.wurst
@@ -177,3 +177,15 @@ function testGenerics()
 @Test function testAsList()
 	asList(1,2,3,4).foldl<int>(0, (i, q) -> q + i)
 		.assertEquals(asList(4,3,2,1).foldl<int>(0, (i, q) -> q + i))
+
+
+@Test function testStringHashCollission()
+	let testlist = new LinkedList<string>
+	testlist.add("a")
+	testlist.add("b")
+	testlist.add("c")
+	testlist.has("a").assertTrue()
+	testlist.has("b").assertTrue()
+	testlist.has("c").assertTrue()
+	testlist.has("x").assertFalse()
+	testlist.has("A").assertFalse()


### PR DESCRIPTION
See #190 

StringHash is not unique, so use linear probing to resolve colliding hashes.

