### PR TITLE
Generalize unit.damageTarget to target widgets

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -259,10 +259,6 @@ public function unit.isInventoryFull() returns boolean
 public function unit.isAlive() returns boolean
 	return UnitAlive(this)
 
-/** Checks if the unit is alive by testing current HP > .405 */
-public function unit.isAliveTrick() returns boolean
-	return this.getHP() > .405
-
 public function unit.issueImmediateOrder(string order) returns boolean
 	return IssueImmediateOrder(this, order)
 

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -113,10 +113,10 @@ public function unit.getSkillPoints() returns int
 public function unit.selectSkill(int abilcode)
 	SelectHeroSkill(this, abilcode)
 
-public function unit.damageTarget(unit target, real amount)
+public function unit.damageTarget(widget target, real amount)
 	UnitDamageTarget(this, target, amount, false, false, ATTACK_TYPE_CHAOS, DAMAGE_TYPE_UNIVERSAL, WEAPON_TYPE_WHOKNOWS)
 
-public function unit.damageTarget(unit target, real amount, attacktype attacktyp)
+public function unit.damageTarget(widget target, real amount, attacktype attacktyp)
 	UnitDamageTarget(this, target, amount, false, false, attacktyp, DAMAGE_TYPE_UNIVERSAL, WEAPON_TYPE_WHOKNOWS)
 
 /** Kills a unit by blowing it up */

--- a/wurst/_handles/Widget.wurst
+++ b/wurst/_handles/Widget.wurst
@@ -19,3 +19,7 @@ public function widget.getY() returns real
 
 public function widget.addEffect(string modelName, string attachment) returns effect
 	return AddSpecialEffectTarget(modelName, this, attachment)
+
+/** Checks if the widget is alive by testing current life > .405 */
+function widget.isAliveTrick() returns bool
+	return .405 < this.getLife()


### PR DESCRIPTION
The previous behaviour was to only accept unit targets.
This change is backward-compatible.

The underlying native

    native UnitDamageTarget             takes unit whichUnit, widget target, real amount, boolean attack, boolean ranged, attacktype attackType, damagetype damageType, weapontype weaponType returns boolean

accepts `widget` targets so I can't think of a reason that the wrapper function `unit.damageTarget` shouldn't do so as well.