### PR TITLE
Move unit.isAliveTrick to widget.isAliveTrick

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -259,10 +259,6 @@ public function unit.isInventoryFull() returns boolean
 public function unit.isAlive() returns boolean
 	return UnitAlive(this)
 
-/** Checks if the unit is alive by testing current HP > .405 */
-public function unit.isAliveTrick() returns boolean
-	return this.getHP() > .405
-
 public function unit.issueImmediateOrder(string order) returns boolean
 	return IssueImmediateOrder(this, order)
 

--- a/wurst/_handles/Widget.wurst
+++ b/wurst/_handles/Widget.wurst
@@ -19,3 +19,7 @@ public function widget.getY() returns real
 
 public function widget.addEffect(string modelName, string attachment) returns effect
 	return AddSpecialEffectTarget(modelName, this, attachment)
+
+/** Checks if the widget is alive by testing current life > .405 */
+function widget.isAliveTrick() returns bool
+	return .405 < this.getLife()


### PR DESCRIPTION
The trick applies to widgets in general and not just units.

Note that there is a technical difference in the implementation:
`unit.isAliveTrick` used the `GetUnitState` native whereas `widget.isAliveTrick`
uses the `GetWidgetLife` native. I'm unaware if there are any differences
in the output of said native functions. I assume not.