### PR TITLE
Generalize unit.damageTarget to target widgets

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -113,10 +113,10 @@ public function unit.getSkillPoints() returns int
 public function unit.selectSkill(int abilcode)
 	SelectHeroSkill(this, abilcode)
 
-public function unit.damageTarget(unit target, real amount)
+public function unit.damageTarget(widget target, real amount)
 	UnitDamageTarget(this, target, amount, false, false, ATTACK_TYPE_CHAOS, DAMAGE_TYPE_UNIVERSAL, WEAPON_TYPE_WHOKNOWS)
 
-public function unit.damageTarget(unit target, real amount, attacktype attacktyp)
+public function unit.damageTarget(widget target, real amount, attacktype attacktyp)
 	UnitDamageTarget(this, target, amount, false, false, attacktyp, DAMAGE_TYPE_UNIVERSAL, WEAPON_TYPE_WHOKNOWS)
 
 /** Kills a unit by blowing it up */


### PR DESCRIPTION
The previous behaviour was to only accept unit targets.
This change is backward-compatible.

The underlying native

    native UnitDamageTarget             takes unit whichUnit, widget target, real amount, boolean attack, boolean ranged, attacktype attackType, damagetype damageType, weapontype weaponType returns boolean

accepts `widget` targets so I can't think of a reason that the wrapper function `unit.damageTarget` shouldn't do so as well.

This pull request is an updated version of https://github.com/wurstscript/WurstStdlib2/pull/192 without the unrelated `isAliveTrick` changes.