### PR TITLE
Define standard annotations

### DIFF
--- a/wurst/Wurst.wurst
+++ b/wurst/Wurst.wurst
@@ -8,3 +8,4 @@ import public Basics
 import public Wurstunit
 import public TypeCasting
 import public Colors
+import public Annotations

--- a/wurst/_handles/Image.wurst
+++ b/wurst/_handles/Image.wurst
@@ -4,6 +4,7 @@ import public Colors
 import Vectors
 import ErrorHandling
 import Player
+import Annotations
 
 public enum Layer
 	L1

--- a/wurst/_handles/Item.wurst
+++ b/wurst/_handles/Item.wurst
@@ -1,6 +1,7 @@
 package Item
 import NoWurst
 import public Vectors
+import Annotations
 
 public function createItem(int itemId, vec2 pos) returns item
 	return createItem(itemId, pos.toVec3())

--- a/wurst/_handles/Player.wurst
+++ b/wurst/_handles/Player.wurst
@@ -2,6 +2,7 @@ package Player
 import NoWurst
 import Wurstunit
 import Unit
+import Annotations
 
 /** Use this array instead of Player() to avoid leaks */
 public player array players

--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -2,6 +2,7 @@ package Unit
 import NoWurst
 import public Vectors
 import Item
+import Annotations
 
 native UnitAlive(unit id) returns boolean
 

--- a/wurst/_wurst/Annotations.wurst
+++ b/wurst/_wurst/Annotations.wurst
@@ -1,0 +1,34 @@
+package Annotations
+import NoWurst
+
+// Meta-annotation:
+
+/** This annotation allows this function to be used as an annotation. */
+@annotation public function annotation()
+
+// built-in annotations
+
+/** This annotation means that this function will be executed when the map is compiled. */
+@annotation public function compiletime()
+
+/** This annotation means that this function should no longer be used. */
+@annotation public function deprecated()
+
+/** This annotation means that this function should no longer be used.
+    The corresponding message is a hint for which function to use instead. */
+@annotation public function deprecated(string _message)
+
+/** Functions annotated with @compiletimenative are natives that are only available at compiletime, but not ingame.  */
+@annotation public function compiletimenative()
+
+/** Elements annotated with @configurable can be configured (i.e. replaced by a different implementation) in configuration packages.  */
+@annotation public function configurable()
+
+/** Functions annotated with @inline will have a higher priority of being inlined by the optimizer. */
+@annotation public function inline()
+
+/** Elements annotated with @config configure an element in the correspoding package (i.e. replaced by a different implementation).  */
+@annotation public function config()
+
+/** Functions annotated with @extern are assumed to be defined in external sources and are thus not included in the compilation output. */
+@annotation public function extern()

--- a/wurst/_wurst/Basics.wurst
+++ b/wurst/_wurst/Basics.wurst
@@ -2,6 +2,7 @@ package Basics
 import public _Primitives
 import Player
 import NoWurst
+import Annotations
 
 /** Standard Period for animation.
 	  Note that 0.03125 is also possible, but doesn't work with order cancel from SetUnitPos */

--- a/wurst/_wurst/ErrorHandling.wurst
+++ b/wurst/_wurst/ErrorHandling.wurst
@@ -7,6 +7,7 @@ import public String
 import GameTimer
 import MagicFunctions
 import Hashtable
+import Annotations
 
 @configurable public var MUTE_ERROR_DURATION = 60
 

--- a/wurst/_wurst/TypeCasting.wurst
+++ b/wurst/_wurst/TypeCasting.wurst
@@ -2,6 +2,7 @@ package TypeCasting
 import NoWurst
 import _Handles
 import Table
+import Annotations
 
 constant typecastdata = new Table()
 /** How many decimals to preserve for reals */

--- a/wurst/_wurst/Wurstunit.wurst
+++ b/wurst/_wurst/Wurstunit.wurst
@@ -3,8 +3,11 @@ import NoWurst
 import Integer
 import Real
 import Boolean
+import Annotations
 // Wurst unit testing library
 
+/** Functions annotated with @test can be executed as unit tests. */
+@annotation public function test()
 
 @deprecated("Use 'println' instead")
 public function testPrint(string msg)

--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -5,6 +5,7 @@ import Integer
 import String
 import ClosureForGroups
 import Real
+import Annotations
 
 /**
  * Doubly-linked list implementation that implements all common list, stack and queue operations.

--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -9,6 +9,7 @@ import GameTimer
 import UnitObjEditing
 import Colors
 import Assets
+import Annotations
 
 /** Id of the dummy unit */
 public constant DUMMY_UNIT_ID 	   		= 'xdum'

--- a/wurst/event/OnUnitEnterLeave.wurst
+++ b/wurst/event/OnUnitEnterLeave.wurst
@@ -10,6 +10,7 @@ import RegisterEvents
 import ObjectIdGenerator
 import MapBounds
 import ClosureTimers
+import Annotations
 
 /* 	Provides event API for units entering and leaving the map.
 	The event will also fire for preplaced units on the map.

--- a/wurst/math/Interpolation.wurst
+++ b/wurst/math/Interpolation.wurst
@@ -2,6 +2,7 @@ package Interpolation
 import NoWurst
 import Vectors
 import Wurstunit
+import Annotations
 
 // Credits to BlinkyBoy
 /** Look at linear */

--- a/wurst/math/Vectors.wurst
+++ b/wurst/math/Vectors.wurst
@@ -5,6 +5,7 @@ import public Real
 import public Angle
 import String
 import initlater Printing
+import Annotations
 
 /** A vector is a geometric object that has a length and direction.
 	Vectors can be added to other vectors according to vector algebra.

--- a/wurst/objediting/AbilityObjEditing.wurst
+++ b/wurst/objediting/AbilityObjEditing.wurst
@@ -8,6 +8,7 @@ import public ObjEditingNatives
 import String
 import public UnitObjEditing
 import Assets
+import Annotations
 
 public enum AllowWhenFull
 	NEVER

--- a/wurst/objediting/ObjEditingNatives.wurst
+++ b/wurst/objediting/ObjEditingNatives.wurst
@@ -1,6 +1,7 @@
 package ObjEditingNatives
 import NoWurst
 import Boolean
+import Annotations
 
 public interface StringLevelClosure
 	function run(int lvl) returns string

--- a/wurst/objediting/ObjectIds.wurst
+++ b/wurst/objediting/ObjectIds.wurst
@@ -6,6 +6,7 @@ import Assets
 import LinkedList
 import StringUtils
 import TypeCasting
+import Annotations
 
 constant CHARMAP = ".................................!.#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[.]^_`abcdefghijklmnopqrstuvwxyz{|}~................................................................................................................................."
 

--- a/wurst/objediting/UnitObjEditing.wurst
+++ b/wurst/objediting/UnitObjEditing.wurst
@@ -3,6 +3,7 @@ import NoWurst
 import ObjEditingNatives
 import public TargetsAllowed
 import public ObjEditingCommons
+import Annotations
 
 public enum MovementType
 	None

--- a/wurst/util/Colors.wurst
+++ b/wurst/util/Colors.wurst
@@ -5,6 +5,7 @@ import String
 import Integer
 import Wurstunit
 import Playercolor
+import Annotations
 
 public constant COLOR_WHITE = colorA(255,255,255,255)
 public constant COLOR_BLACK = colorA(0,0,0,0)

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -5,6 +5,7 @@ import ErrorHandling
 import HashMap
 import Execute
 import Maths
+import Annotations
 
 /*
 	Groups are a necessary evil that exists in warcraft 3, and sometimes their use

--- a/wurst/util/MapBounds.wurst
+++ b/wurst/util/MapBounds.wurst
@@ -5,6 +5,7 @@ import Wurstunit
 import Region
 import Rect
 import MagicFunctions
+import Annotations
 
 public rect playableMapRect
 public region playableMapRegion

--- a/wurst/util/Preloader.wurst
+++ b/wurst/util/Preloader.wurst
@@ -7,6 +7,7 @@ import ObjectIds
 import Basics
 import ClosureTimers
 import ClosureForGroups
+import Annotations
 
 /* Helps you to preload units and abilities during map-load	*
  * to avoid first-laggs. */

--- a/wurst/util/Printing.wurst
+++ b/wurst/util/Printing.wurst
@@ -1,6 +1,7 @@
 package Printing
 import NoWurst
 import Player
+import Annotations
 
 @configurable public var DEBUG_LEVEL = Loglevel.INFO
 @configurable public var DEBUG_MSG_DURATION = 45.

--- a/wurst/util/StringUtils.wurst
+++ b/wurst/util/StringUtils.wurst
@@ -5,6 +5,7 @@ import LinkedList
 import Texttag
 import Interpolation
 import TypeCasting
+import Annotations
 
 /**
  * Credits go here: http://www.hiveworkshop.com/forums/jass-resources-412/snippet-ascii-190746/


### PR DESCRIPTION
Since Wurst will now gives a warning for undefined annotations, this PR adds the predefined annotations to the standard library in `Annotations.wurst`.