### PR TITLE
ClosureForGroups fix

### DIFF
--- a/wurst/closures/ClosureForGroups.wurst
+++ b/wurst/closures/ClosureForGroups.wurst
@@ -93,11 +93,15 @@ public function forUnitsInRectCounted(rect r, int count, ForGroupCallback c)
 
 /** Executes the given closure for every unit in range of the given position */
 public function forUnitsInRange(vec2 pos, real radius, ForGroupCallback c)
-	forUnitsInRange(pos, radius, c, false)
+	forUnitsInRange(pos, radius, false, c)
+
+@deprecated("Use forUnitsInRange(pos, radius, collisionSizeFiltering, c) instead") 
+public function forUnitsInRange(vec2 pos, real radius, ForGroupCallback c, bool collisionSizeFiltering)
+	forUnitsInRange(pos, radius, collisionSizeFiltering, c)
 
 /** Executes the given closure for every unit in range of the given position 
 	With collisionSizeFiltering true it will take the units' collision into account. */
-public function forUnitsInRange(vec2 pos, real radius, ForGroupCallback c, bool collisionSizeFiltering)
+public function forUnitsInRange(vec2 pos, real radius, bool collisionSizeFiltering, ForGroupCallback c)
 	if collisionSizeFiltering
 		pushCallback(c)
 		GroupEnumUnitsInRange(ENUM_GROUP, pos.x, pos.y, radius + MAX_COLLISION_SIZE, null)


### PR DESCRIPTION
Changed the new forUnitsInRange() to allow for the () -> syntax.
I believe the callback has to be the last argument.