### PR TITLE
Add reset method to HLIterator

### DIFF
--- a/wurst/data/HashList.wurst
+++ b/wurst/data/HashList.wurst
@@ -129,5 +129,8 @@ public class HLIterator<Q>
 		i++
 		return list.get(i - 1)
 
+	function reset()
+		i = 0
+
 	function close()
 		destroy this


### PR DESCRIPTION
Small addition. Should be backwards compatible.

I need this to implement an efficient `staticItr()` in a module.