### PR TITLE
Allow dummy caster unit to attack when ordered

### DIFF
--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -186,7 +186,7 @@ init
 	..setAttack1DamageSidesperDie(1)
 	..setAttack1ProjectileSpeed(INT_MAX)
 	..setAttack1Range(INT_MAX)
-	..setAttack1TargetsAllowed("air,debris,ground,invulnerable,item,structure,vulnerable,ward")
+	..setAttack1TargetsAllowed(commaList(TargetsAllowed.air, TargetsAllowed.debris, TargetsAllowed.ground, TargetsAllowed.invulnerable, TargetsAllowed.item_t, TargetsAllowed.structure, TargetsAllowed.vulnerable, TargetsAllowed.ward))
 	..setAttack1WeaponSound(WeaponSound.Nothing)
 	..setAttack1WeaponType(WeaponType.Instant)
 	..setAcquisitionRange(INT_MAX.toReal())

--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -150,6 +150,7 @@ public constant DISABLE_AUTO_ACQUIRE_ATTACK_TARGETS_ABILITY_ID = 'xdaa'
 	..presetAutoAcquireAttackTargets(_ -> false)
 	..presetDurationNormal(_ -> -1)
 	..presetDurationHero(_ -> -1)
+	
 	new UnitDefinition(DUMMY_UNIT_ID, UnitIds.wisp)
 	..setName("Effect Dummy Unit")
 	..setUpgradesUsed("")

--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -7,7 +7,6 @@ import ErrorHandling
 import MapBounds
 import GameTimer
 import AbilityObjEditing
-import initlater ObjectIdGenerator
 import ObjectIds
 import Colors
 import Assets
@@ -143,14 +142,16 @@ init
 		DummyRecycler.angleQueues[i] = new ArrayQueue()
 		for j = 0 to SAVED_UNITS_PER_ANGLE - 1
 			DummyRecycler.angleQueues[i].enqueue(createDummy(boundMax, DUMMY_PLAYER, (i* ANGLE_DEGREE).asAngleDegrees()))
+			
+public constant DISABLE_AUTO_ACQUIRE_ATTACK_TARGETS_ABILITY_ID = 'xdaa'
 
 @compiletime function generateDummyUnit()
-	let a = new AbilityDefinitionPermanentInvisibility(ABIL_ID_GEN.next())
-	a..presetAutoAcquireAttackTargets(_ -> false)
+	new AbilityDefinitionPermanentInvisibility(DISABLE_AUTO_ACQUIRE_ATTACK_TARGETS_ABILITY_ID)
+	..presetAutoAcquireAttackTargets(_ -> false)
 	..presetDurationNormal(_ -> -1)
 	..presetDurationHero(_ -> -1)
-	let u = new UnitDefinition(DUMMY_UNIT_ID, UnitIds.wisp)
-	u..setName("Effect Dummy Unit")
+	new UnitDefinition(DUMMY_UNIT_ID, UnitIds.wisp)
+	..setName("Effect Dummy Unit")
 	..setUpgradesUsed("")
 	..setStructuresBuilt("")
 	..setManaRegeneration(0.1)
@@ -190,5 +191,5 @@ init
 	..setAttack1WeaponSound(WeaponSound.Nothing)
 	..setAttack1WeaponType(WeaponType.Instant)
 	..setAcquisitionRange(INT_MAX.toReal())
-	..setNormalAbilities(commaList(AbilityIds.invulnerable, AbilityIds.locust, a.getNewId()))
+	..setNormalAbilities(commaList(AbilityIds.invulnerable, AbilityIds.locust, DISABLE_AUTO_ACQUIRE_ATTACK_TARGETS_ABILITY_ID))
 

--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -6,7 +6,9 @@ import Basics
 import ErrorHandling
 import MapBounds
 import GameTimer
-import UnitObjEditing
+import AbilityObjEditing
+import initlater ObjectIdGenerator
+import ObjectIds
 import Colors
 import Assets
 import Annotations
@@ -143,6 +145,10 @@ init
 			DummyRecycler.angleQueues[i].enqueue(createDummy(boundMax, DUMMY_PLAYER, (i* ANGLE_DEGREE).asAngleDegrees()))
 
 @compiletime function generateDummyUnit()
+	let a = new AbilityDefinitionPermanentInvisibility(ABIL_ID_GEN.next())
+	a..presetAutoAcquireAttackTargets(_ -> false)
+	..presetDurationNormal(_ -> -1)
+	..presetDurationHero(_ -> -1)
 	let u = new UnitDefinition(DUMMY_UNIT_ID, UnitIds.wisp)
 	u..setName("Effect Dummy Unit")
 	..setUpgradesUsed("")
@@ -170,5 +176,19 @@ init
 	..setUnitClassification("_")
 	..setPropulsionWindowdegrees(1.0)
 	..setTooltipBasic("")
-	..setNormalAbilities("Avul,Aloc")
+	..setAttacksEnabled(AttacksEnabled.AttackOneOnly.toObjectInt())
+	..setAttack1AnimationBackswingPoint(0)
+	..setAttack1AnimationDamagePoint(0)
+	..setAttack1CooldownTime(0)
+	..setAttack1AttackType(AttackType.Unknown)
+	..setAttack1DamageBase(-1)
+	..setAttack1DamageNumberofDice(1)
+	..setAttack1DamageSidesperDie(1)
+	..setAttack1ProjectileSpeed(INT_MAX)
+	..setAttack1Range(INT_MAX)
+	..setAttack1TargetsAllowed("air,debris,ground,invulnerable,item,structure,vulnerable,ward")
+	..setAttack1WeaponSound(WeaponSound.Nothing)
+	..setAttack1WeaponType(WeaponType.Instant)
+	..setAcquisitionRange(INT_MAX.toReal())
+	..setNormalAbilities(commaList(AbilityIds.invulnerable, AbilityIds.locust, a.getNewId()))
 


### PR DESCRIPTION
This change allows to use dummy casters with "attackonce" order. It may be useful in the following pattern:
`new DummyCaster().castTarget(AbilityIds.poisonSting, 1, OrderIds.attackonce, target)`
The target unit will be poisoned.

This does not break compatibility since the dummy won't attack unless explicitly ordered thanks to the special ability based on permanent invisibility.