### PR TITLE
Rename vec2.op_div to vec2.op_divReal

### DIFF
--- a/wurst/math/Vectors.wurst
+++ b/wurst/math/Vectors.wurst
@@ -49,7 +49,7 @@ public function vec2.op_mult(vec2 v) returns vec2
 	return vec2(this.x * v.x, this.y * v.y)
 
 /** * Operator */
-public function vec2.op_div(real factor) returns vec2
+public function vec2.op_divReal(real factor) returns vec2
 	return vec2(this.x / factor, this.y / factor)
 
 /** Add two reals to the coordiantes of this vector */


### PR DESCRIPTION
This issue has been there since 2014 according to the [WurstScript changelog](https://github.com/wurstscript/WurstScript/blob/4adc23008880d2f6305d9f7207722ae3ed97aa04/CHANGELOG.md#1400-2014-03-15).