### PR TITLE
mat3 and quat fixes for effect orientation

### DIFF
--- a/wurst/_handles/Effect.wurst
+++ b/wurst/_handles/Effect.wurst
@@ -97,11 +97,11 @@ public function effect.setOrientation(real yaw, real pitch, real roll)
 
 public function effect.setOrientation(mat3 matrix)
 	let euler = matrix.toEuler()
-	BlzSetSpecialEffectOrientation(this, euler.x, euler.y, euler.z)
+	BlzSetSpecialEffectOrientation(this, euler.z, euler.y, euler.x)
 
 public function effect.setOrientation(quat quaternion)
 	let euler = quaternion.toEuler()
-	BlzSetSpecialEffectOrientation(this, euler.x, euler.y, euler.z)
+	BlzSetSpecialEffectOrientation(this, euler.z, euler.y, euler.x)
 
 public function effect.setYaw(real yaw)
 	BlzSetSpecialEffectYaw(this, yaw)

--- a/wurst/math/Matrices.wurst
+++ b/wurst/math/Matrices.wurst
@@ -37,6 +37,8 @@ public constant IDENTITY33 = mat3(  1, 0, 0,
 
 tuple inverseresult33(bool success, mat3 matrix)
 
+constant EPSILON = 0.001
+
 /* =========== 2X2 MATRIX =========== */
 
 public function mat2.op_plus(mat2 m) returns mat2
@@ -112,7 +114,7 @@ Returns tuple inverseresult22(bool success, mat2 matrix) where 'success' is true
 If there's no inverse matrix 'success' is false and 'matrix' is zero matrix. */
 public function mat2.inverse() returns inverseresult22
 	let d = this.determinant()
-	var inverse = inverseresult22(d.abs() > 0.002, ZERO22)
+	var inverse = inverseresult22(d.abs() > EPSILON, ZERO22)
 	if inverse.success
 		let tmp = mat2( this.m11, -this.m01,
 						-this.m10, this.m00)
@@ -238,7 +240,7 @@ Returns tuple inverseresult33(bool success, mat3 matrix) where 'success' is true
 If there's no inverse matrix 'success' is false and 'matrix' is zero matrix. */
 public function mat3.inverse() returns inverseresult33
 	let d = this.determinant()
-	var inverse = inverseresult33(d.abs() > 0.002, ZERO33)
+	var inverse = inverseresult33(d.abs() > EPSILON, ZERO33)
 	if inverse.success
 		let tmp = mat3( this.m11 * this.m22 - this.m12 * this.m21,
 						this.m02 * this.m21 - this.m01 * this.m22,
@@ -254,24 +256,24 @@ public function mat3.inverse() returns inverseresult33
 		inverse.matrix = 1 / d * tmp
 	return inverse
 
-/** Extracts Euler-angles (Tait-Bryan) in radians from rotation matrix. Order of the result is X-Y-Z. */
+/** Extracts Euler-angles (Tait-Bryan) in radians from a rotation matrix. Order of the result is Z-Y-X (Yaw-Pitch-Roll). */
 public function mat3.toEuler() returns vec3
 	real yaw
 	real pitch
 	real roll
-	if this.m02 > 0.999
-		yaw = Atan2(this.m21, this.m11)
-		pitch = PI / 2
-		roll = 0
-	else if this.m02 < -0.999
-		yaw = Atan2(this.m21, this.m11)
+	if this.m20 > 1 - EPSILON
+		yaw = Atan2(-this.m12, -this.m02)
 		pitch = -PI / 2
+		roll = 0
+	else if this.m20 < EPSILON - 1
+		yaw = Atan2(this.m12, this.m02)
+		pitch = PI / 2
 		roll  = 0
 	else
-		yaw  = Atan2(-this.m12, this.m22)
-		pitch = Asin(this.m02)
-		roll = Atan2(-this.m01 , this.m00)
-	return vec3(yaw, pitch, roll)
+		yaw  = Atan2(this.m10, this.m00)
+		pitch = -Asin(this.m20)
+		roll = Atan2(this.m21 , this.m22)
+	return vec3(roll, pitch, yaw)
 
 public function mat3.toString() returns string
 	return "Matrix 3x3\n{0} {1} {2}\n{3} {4} {5}\n{6} {7} {8}".format(
@@ -287,9 +289,9 @@ public function vec3.toRotation(angle angl) returns mat3
 	var z = v.z
 	var mcos = 1 - angl.cos()
 	var sin = angl.sin()
-	return mat3(1 + mcos * (x * x - 1),	 -z * sin + mcos * x * y,	 y * sin + mcos * x * z,
-				z * sin + mcos * x * y,	  1 + mcos * (y * y - 1),	-x * sin + mcos * y * z,
-				-y * sin + mcos * x * z,	 x * sin + mcos * y * z,	 1 + mcos * (z * z - 1))
+	return mat3(1 + mcos * (x * x - 1),	 	-z * sin + mcos * x * y,	 y * sin + mcos * x * z,
+				z * sin + mcos * x * y,	  	1 + mcos * (y * y - 1),		-x * sin + mcos * y * z,
+				-y * sin + mcos * x * z,	x * sin + mcos * y * z,	 	1 + mcos * (z * z - 1))
 
 /** Creates 3x3 rotation matrix from axis and angle. */
 public function angle.toRotation(vec3 axis) returns mat3

--- a/wurst/math/MatricesTests.wurst
+++ b/wurst/math/MatricesTests.wurst
@@ -2,6 +2,7 @@ package MatricesTests
 import NoWurst
 import Wurstunit
 import Matrices
+import Printing
 
 /* =========== 2X2 MATRIX =========== */
 
@@ -228,7 +229,7 @@ import Matrices
 	let aroundX = angle(euler.x).toRotation(vec3(1, 0, 0))
 	let aroundY = angle(euler.y).toRotation(vec3(0, 1, 0))
 	let aroundZ = angle(euler.z).toRotation(vec3(0, 0, 1))
-	(aroundX * aroundY * aroundZ).assertEquals(test)
+	(aroundZ * aroundY * aroundX).assertEquals(test)
 
 @test function test33rotationsXYZ()
 	let test = vec3(1, 2, 3)

--- a/wurst/math/Quaternion.wurst
+++ b/wurst/math/Quaternion.wurst
@@ -10,6 +10,8 @@ public tuple quat(real x, real y, real z, real w)
 public constant IDENTITYQ = quat(0, 0, 0, 1)
 public constant ZEROQ = quat(0, 0, 0, 0)
 
+constant EPSILON = 0.001
+
 public function quat.op_plus(quat q) returns quat
 	return quat(this.x + q.x, this.y + q.y, this.z + q.z, this.w + q.w)
 
@@ -51,15 +53,15 @@ public function quat.length() returns real
 /** Returns zero quaternion if lenght is zero. */
 public function quat.norm() returns quat
 	let length = this.length()
-	return length > 0.002 ? quat(this.x / length, this.y / length, this.z / length, this.w / length) : ZEROQ
+	return length > EPSILON ? quat(this.x / length, this.y / length, this.z / length, this.w / length) : ZEROQ
 
 /** Quaternion to power of alpha. */
 public function quat.exp(real alpha) returns quat
 	var result = ZEROQ
 	let norm = this.length()
-	if norm > 0.002 // zero is zero...
+	if norm > EPSILON // zero is zero...
 		var n = vec3(this.x, this.y, this.z)
-		if n.length() > 0.002
+		if n.length() > EPSILON
 			let theta = (this.w / norm).acos()
 			let x = theta * alpha
 			let normPow = norm.pow(alpha)
@@ -103,7 +105,7 @@ public function quat.getZ() returns vec3
 q - targeted quaternion. p - progress from 0 to 1. */
 public function quat.lerp(quat q, real p) returns quat
 	quat result
-	if this.dot(q).abs() < 0.002
+	if this.dot(q).abs() < EPSILON
 		result = q
 	else
 		result = this * (1 - p) + q * p
@@ -144,7 +146,7 @@ Slerp is the least efficient approach in performance so try to avoid using it, u
 public function quat.slerp(quat q, real p) returns quat
 	quat result
 	let dot = this.dot(q)
-	if dot.abs() < 0.002
+	if dot.abs() < EPSILON
 		result = q
 	else
 		let theta = dot.acos()
@@ -171,38 +173,38 @@ public function quat.toString() returns string
 /** Gimbal lock detection.
 Returns 1 for north, -1 for south, 0 if no gimbal lock. */
 public function quat.getGimbalPole() returns int
-	let pole = this.x * this.z + this.y * this.w
-	return pole > 0.499 ? 1 : (pole < -0.499 ? -1 : 0)
+	let pole = this.x * this.z - this.y * this.w
+	return pole > 0.5 - EPSILON ? 1 : (pole < EPSILON - 0.5 ? -1 : 0)
 
-/** Extracts Euler-angles (Tait-Bryan) in radians from a quaternion. Order of the result is X-Y-Z. */
+/** Extracts Euler-angles (Tait-Bryan) in radians from a quaternion. Order of the result is Z-Y-X (Yaw-Pitch-Roll). */
 public function quat.toEuler() returns vec3
 	real yaw
 	real pitch
 	real roll
 	real cos
 	real sin
-	let pole = this.x * this.z + this.y * this.w
-	if pole > 0.499
-		cos = 1 - 2 * this.x * this.x - 2 * this.z * this.z
-		sin = 2 * this.y * this.z + 2 * this.x * this.w
-		yaw = Atan2(sin, cos)
-		pitch = PI / 2
-		roll = 0
-	else if pole < -0.499
-		cos = 1 - 2 * this.x * this.x - 2 * this.z * this.z
-		sin = 2 * this.y * this.z + 2 * this.x * this.w
-		yaw = Atan2(sin, cos)
-		pitch = -PI / 2
-		roll  = 0
-	else
-		cos = 1 - 2 * this.x * this.x - 2 * this.y * this.y
-		sin = -(2 * this.y * this.z - 2 * this.x * this.w)
-		yaw  = Atan2(sin, cos)
-		pitch = Asin(2 * pole)
-		cos = 1 - 2 * this.y * this.y - 2 * this.z * this.z
-		sin = -(2 * this.x * this.y - 2 * this.z * this.w)
-		roll = Atan2(sin , cos)
-	return vec3(yaw, pitch, roll)
+	switch this.getGimbalPole()
+		case 1
+			cos = 2 * this.x * this.z + 2 * this.y * this.w
+			sin = 2 * this.y * this.z - 2 * this.x * this.w
+			yaw = Atan2(-sin, -cos)
+			pitch = -PI / 2
+			roll = 0
+		case -1
+			cos = 2 * this.x * this.z + 2 * this.y * this.w
+			sin = 2 * this.y * this.z - 2 * this.x * this.w
+			yaw = Atan2(sin, cos)
+			pitch = PI / 2
+			roll  = 0
+		default
+			cos = 1 - 2 * this.y * this.y - 2 * this.z * this.z
+			sin = 2 * this.x * this.y + 2 * this.z * this.w
+			yaw  = Atan2(sin, cos)
+			pitch = -Asin(2 * this.x * this.z - 2 * this.y * this.w)
+			cos = 1 - 2 * this.x * this.x - 2 * this.y * this.y
+			sin = 2 * this.y * this.z + 2 * this.x * this.w
+			roll = Atan2(sin , cos)
+	return vec3(roll, pitch, yaw)
 
 /** Creates a quaternion from rotation axis and angle. */
 public function vec3.toQuat(angle angl) returns quat

--- a/wurst/math/QuaternionTests.wurst
+++ b/wurst/math/QuaternionTests.wurst
@@ -82,7 +82,7 @@ import Quaternion
 	works is producing backward convertation by sequence of rotations
 	acording to the order in the angles. Obtained result must be
 	the quaternion we've started from. */
-	aroundX.cross(aroundY).cross(aroundZ).assertEquals(test)
+	aroundZ.cross(aroundY).cross(aroundX).assertEquals(test)
 
 @Test function testVec3Rotate()
 	let rot = vec3(0, 0, 1).toQuat((-90) .asAngleDegrees())
@@ -128,8 +128,8 @@ import Quaternion
 	start.slerpShort(finish, 0.5).assertEquals(expected)
 
 @Test function testGetGimbalPole()
-	let north = vec3(0, 1, 0).toQuat(90 .asAngleDegrees())
-	let south = vec3(0, 1, 0).toQuat(270 .asAngleDegrees())
+	let north = vec3(0, 1, 0).toQuat(270 .asAngleDegrees())
+	let south = vec3(0, 1, 0).toQuat(90 .asAngleDegrees())
 	let clear = vec3(1, 1, 1).norm().toQuat(90 .asAngleDegrees())
 	north.getGimbalPole().assertEquals(1)
 	south.getGimbalPole().assertEquals(-1)


### PR DESCRIPTION
Related to #297 
1.29 patch brought the effect-orientation control to the game. It used Euler-angles in order `X-Y-Z` which was quite confusing according to names `Yaw-Pitch-Roll`. In the latest patches this was changed. Now, `Yaw` defines rotation around `Z` axis and `Roll` defines rotation around `X` axis and the rotation order (according to `Yaw-Pitch-Roll`) has become `Z-Y-X`.
This PR fixes the issues in the standard library which appeared with the game's changes. Thanks to Blizzard for non-mentioning these changes in the patch notes so it took me a while to notice the problem.

```
Tests succeeded: 22/22
>> All tests have passed successfully!
Tests succeeded: 35/35
>> All tests have passed successfully!
```

![ezgif com-optimize(5)](https://user-images.githubusercontent.com/19322847/65993229-de2efe00-e4a1-11e9-9635-730f52f4dd91.gif)
