### PR TITLE
make `compiletime` magic function generic

### DIFF
--- a/wurst/_wurst/MagicFunctions.wurst
+++ b/wurst/_wurst/MagicFunctions.wurst
@@ -28,23 +28,5 @@ public constant compiletime = false
 /** This is a builtin magic function.
  * It evaluates it's argument at compiletime and replaces the call with the result.
  */
-public function compiletime(int expr) returns int
-	return expr
-
-/** This is a builtin magic function.
- * It evaluates it's argument at compiletime and replaces the call with the result.
- */
-public function compiletime(real expr) returns real
-	return expr
-
-/** This is a builtin magic function.
- * It evaluates it's argument at compiletime and replaces the call with the result.
- */
- public function compiletime(string expr) returns string
+ public function compiletime<T:>(T expr) returns T
 	 return expr
-
-/** This is a builtin magic function.
- * It evaluates it's argument at compiletime and replaces the call with the result.
- */
- public function compiletime(boolean expr) returns boolean
- 	return expr

--- a/wurst/objediting/BuffObjEditing.wurst
+++ b/wurst/objediting/BuffObjEditing.wurst
@@ -42,9 +42,6 @@ public function createDummyBuffObject(string name, string tooltip, string iconpa
 
 	return buffTuple(abilId, buffId)
 
-public function compiletime(buffTuple buffT) returns buffTuple
-	return buffT
-
 public class BuffDefinition
 	ObjectDefinition def
 


### PR DESCRIPTION
Would allow to create objects at compiletime with comfort without needing to declare a `compiletime` function with an argument of the needed type each time. What's more, that is the only way to allow to create both an object of type `class A` and an object of type `class B extends A` at compiletime: if you declare `compiletime` functions with arguments of the concrete types, you would not be able to create an object of type B without casting it from A to B, and if you declare generic `compiletime` function, it would be ambiguous with the built-in ones.