### PR TITLE
FunctionalInterfaces package

### DIFF
--- a/wurst/_wurst/FunctionalInterfaces.wurst
+++ b/wurst/_wurst/FunctionalInterfaces.wurst
@@ -15,11 +15,6 @@ public interface BiFunction<T:, U:, R:>
 /** Represents an operation upon two operands of the same type, producing a result of the same type as the operands. */
 public interface BinaryOperator<T:> extends BiFunction<T, T, T>
 
-    int a = 0
-
-    construct(int a)
-        print(a)
-
 /** Represents a predicate (boolean-valued function) of two arguments. */
 public interface BiPredicate<T:, U:> extends BiFunction<T, U, bool>
 

--- a/wurst/_wurst/FunctionalInterfaces.wurst
+++ b/wurst/_wurst/FunctionalInterfaces.wurst
@@ -1,0 +1,60 @@
+package FunctionalInterfaces
+
+/** Represents an operation that accepts two input arguments and returns no result. */
+public interface BiConsumer<T:, U:>
+
+    /** Performs this operation on the given arguments. */
+    function accept(T t, U u)
+
+/** Represents a function that accepts two arguments and produces a result. */
+public interface BiFunction<T:, U:, R:>
+
+    /** Applies this function to the given arguments. */
+    function apply(T t, U u) returns R
+
+/** Represents an operation upon two operands of the same type, producing a result of the same type as the operands. */
+public interface BinaryOperator<T:> extends BiFunction<T, T, T>
+
+    int a = 0
+
+    construct(int a)
+        print(a)
+
+/** Represents a predicate (boolean-valued function) of two arguments. */
+public interface BiPredicate<T:, U:> extends BiFunction<T, U, bool>
+
+    override function apply(T t, U u) returns bool
+        return test(t, u)
+
+    /** Evaluates this predicate on the given arguments. */
+    function test(T t, U u) returns bool
+
+/** Represents an operation that accepts a single input argument and returns no result. */
+public interface Consumer<T:>
+
+    /** Performs this operation on the given argument. */
+    function accept(T t)
+
+/** Represents a function that accepts one argument and produces a result. */
+public interface Function<T:, R:>
+
+    /** Applies this function to the given argument. */
+    function apply(T t) returns R
+
+/** Represents an operation on a single operand that produces a result of the same type as its operand. */
+public interface UnaryOperator<T:> extends Function<T, T>
+
+/** Represents a predicate (boolean-valued function) of one argument. */
+public interface Predicate<T:> extends Function<T, bool>
+
+    override function apply(T t) returns bool
+        return test(t)
+
+    /** Evaluates this predicate on the given argument. */
+    function test(T t) returns bool
+
+/** Represents a supplier of results. */
+public interface Supplier<T:>
+
+    /** Gets a result. */
+    function get() returns T


### PR DESCRIPTION
There are many cases when a function accepts a closure. Very often it's just a predicate or a binary function, but you have to declare a new interface each time in each package. These package provides common functional interfaces to use them everywhere instead of declaring new interfaces.