### PR TITLE
fix ObjectDefinition in compiletime

### DIFF
--- a/wurst/_handles/Effect.wurst
+++ b/wurst/_handles/Effect.wurst
@@ -20,11 +20,11 @@ public function flashEffect(string path, vec2 pos, real scale)
 public function flashEffect(string path, vec3 pos, real scale)
 	flashEffect(path, pos, scale, GetRandomReal(0, 359).fromDeg())
 
-public function flashEffect(string path, vec2 pos, real scale, angle roll)
-	addEffect(path, pos)..setScale(scale)..setRoll(roll)..destr()
+public function flashEffect(string path, vec2 pos, real scale, angle yaw)
+	addEffect(path, pos)..setScale(scale)..setYaw(yaw)..destr()
 
-public function flashEffect(string path, vec3 pos, real scale, angle roll)
-	addEffect(path, pos)..setScale(scale)..setRoll(roll)..destr()
+public function flashEffect(string path, vec3 pos, real scale, angle yaw)
+	addEffect(path, pos)..setScale(scale)..setYaw(yaw)..destr()
 
 public function flashEffect(string path, widget target, string attachPointName)
 	addEffect(path, target, attachPointName).destr()

--- a/wurst/objediting/ObjEditingNatives.wurst
+++ b/wurst/objediting/ObjEditingNatives.wurst
@@ -16,13 +16,13 @@ public interface BooleanLevelClosure
 	function run(int lvl) returns boolean
 
 
-public tuple ObjectDefinition(int key)
+public tuple ObjectDefinition(string key)
 
 // creates a new unit objectdefinition
 // for example to create a new unit with id "h000" which is based on a footman ("hfoo")
 // let u = createObjectDefinition("w3u", "h000", "hfoo")
 @compiletimenative public function createObjectDefinition(string fileType, int newId, int deriveFrom) returns ObjectDefinition
-	return ObjectDefinition(0) // dummy implementation
+	return ObjectDefinition(null) // dummy implementation
 
 // changes an int value of an objectdefinition
 @compiletimenative public function ObjectDefinition.setInt(string modification, int value)


### PR DESCRIPTION
ObjectDefinitions have string keys in the compiler.

The following code does not compile without this fix:

```
let a = compiletime(new UnitDefinition('xxxx', 'hfoo'))
```

The reason is that's the compiler uses string keys, the stdlib uses int keys. It compiles into assigning in string to integer, which fails compilation at pJass stage. This PR fixes the issue.

(Note that it works even without this fix in `@compiletime` functions, because objects created in such functions are not being transmitted to runtime)