### PR TITLE
Add executeUnsafe to Execute package

### DIFF
--- a/wurst/closures/Execute.wurst
+++ b/wurst/closures/Execute.wurst
@@ -96,7 +96,7 @@ public function try(ForForceCallback c) returns boolean
 	pushCallback(c)
 	let suppressErrors = suppressErrorMessages
 	suppressErrorMessages = true
-	executeForce.forEach(function executeCurrentCallback)
+	executeUnsafe(function executeCurrentCallback)
 	suppressErrorMessages = suppressErrors
 	popCallback()
 	return isLastCallbackSuccessful()
@@ -127,3 +127,9 @@ public function executeWhile(int resetCount, LimitedExecuteCondition condition, 
 	executeWhileInternal(resetCount, condition, action)
 	destroy condition
 	destroy action
+
+/**
+	A handy wrapper of ForForce.
+**/
+public function executeUnsafe(code callback)
+	executeForce.forEach(callback)


### PR DESCRIPTION
A handy wrapper to access executeForce.forEach.

execute is an overkill for some simple tasks such as static function, map init..
Using execute in multiple places will generate closures and caused some overhead.
