### PR TITLE
three changes to Knockback3

### DIFF
--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -153,6 +153,11 @@ public class Knockback3
 		return unitNodes.has(u) ? unitNodes.get(u).del : ZERO3
 
 
+	static function forget(unit u)
+		if unitNodes.has(u)
+			destroy unitNodes.get(u)
+
+
 	// Instance Variables
 	private unit u
 	private vec3 del
@@ -217,15 +222,14 @@ public class Knockback3
 
 	private static constant unitNodes = new HashMap<unit, Knockback3>()
 
-	private static function tickUnitDone(Knockback3 knockback)
-		knockback.u.setFlyHeight(0., 0.)
-		unitNodes.remove(knockback.u)
+	ondestroy
+		unitNodes.remove(this.u)
 
 		if USE_MOVE_SPEED_MODIFIERS
-			knockback.u.setMoveSpeed(knockback.u.getDefaultMovespeed())
+			this.u.setMoveSpeed(this.u.getDefaultMovespeed())
 
 		if USE_PROP_WINDOW_MODIFIERS
-			knockback.u.setPropWindow(knockback.u.getDefaultPropWindow() * bj_DEGTORAD)
+			this.u.setPropWindow(this.u.getDefaultPropWindow() * bj_DEGTORAD)
 
 
 	private static let clock = CreateTimer()
@@ -250,8 +254,17 @@ public class Knockback3
 			if velXySquared > destroyDestructableSpeedThreshold * ANIMATION_PERIOD and pos3.z < destroyDestructableHeightThreshold
 				tickTryDestructable(knockback, newPos3)
 
-			if velXySquared < minimumSlideSpeed * ANIMATION_PERIOD and knockback.del.z > elasticityThreshold * ANIMATION_PERIOD and knockback.del.z < -1 * elasticityThreshold * ANIMATION_PERIOD and pos3.z < isAirborneThreshold
-				tickUnitDone(knockback)
+			if (
+				// Horizontal velocity is low.
+				velXySquared < minimumSlideSpeed * ANIMATION_PERIOD
+			) and (
+				// Vertical velocity is low.
+				knockback.del.z.abs() < -1. * elasticityThreshold * ANIMATION_PERIOD
+			) and (
+				// Not airborne.
+				pos3.z < isAirborneThreshold
+			)
+				knockback.u.setFlyHeight(0., 0.)
 				destroy knockback
 
 		if size == 0

--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -154,7 +154,7 @@ public class Knockback3
 
 
 	/**
-		Getting for the knockback vector on unit u.  If the unit is not already tracked, returns (0, 0, 0).
+		Getter for the knockback vector on unit u.  If the unit is not already tracked, returns (0, 0, 0).
 	*/
 	static function getVel(unit u) returns vec3
 		return unitNodes.has(u) ? unitNodes.get(u).del : ZERO3

--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -139,6 +139,10 @@ public class Knockback3
 		add(u, speed, theta, vec2(groundSpeed, vel.z).getAngle())
 
 
+	/**
+		Setter for the knockback vector on unit u.  If the unit is not already tracked, this has the same behavior as
+		`add`.
+	*/
 	static function setVel(unit u, real velocity, angle groundAngle, angle airAngle)
 		if unitNodes.has(u)
 			let knockback = unitNodes.get(u)
@@ -149,10 +153,17 @@ public class Knockback3
 			add(u, velocity, groundAngle, airAngle)
 
 
+	/**
+		Getting for the knockback vector on unit u.  If the unit is not already tracked, returns (0, 0, 0).
+	*/
 	static function getVel(unit u) returns vec3
 		return unitNodes.has(u) ? unitNodes.get(u).del : ZERO3
 
 
+	/**
+		Stop tracking unit u.  If the unit is middair it will simply stop moving.  If the unit is already untracked,
+		nothing happens.
+	*/
 	static function forget(unit u)
 		if unitNodes.has(u)
 			destroy unitNodes.get(u)
@@ -254,16 +265,10 @@ public class Knockback3
 			if velXySquared > destroyDestructableSpeedThreshold * ANIMATION_PERIOD and pos3.z < destroyDestructableHeightThreshold
 				tickTryDestructable(knockback, newPos3)
 
-			if (
-				// Horizontal velocity is low.
-				velXySquared < minimumSlideSpeed * ANIMATION_PERIOD
-			) and (
-				// Vertical velocity is low.
-				knockback.del.z.abs() < -1. * elasticityThreshold * ANIMATION_PERIOD
-			) and (
-				// Not airborne.
-				pos3.z < isAirborneThreshold
-			)
+			let is_vel_xy_low = velXySquared < (minimumSlideSpeed * minimumSlideSpeed) * ANIMATION_PERIOD
+			let is_vel_z_low = knockback.del.z.abs() < -1. * elasticityThreshold * ANIMATION_PERIOD
+			let is_airborne = pos3.z > isAirborneThreshold
+			if is_vel_xy_low and is_vel_z_low and not is_airborne
 				knockback.u.setFlyHeight(0., 0.)
 				destroy knockback
 

--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -140,7 +140,7 @@ public class Knockback3
 
 
 	/**
-		Setter for the knockback vector on unit u.  If the unit is not already tracked, this has the same behavior as
+		Setter for the knockback vector on unit u. If the unit is not already tracked, this has the same behavior as
 		`add`.
 	*/
 	static function setVel(unit u, real velocity, angle groundAngle, angle airAngle)
@@ -161,7 +161,7 @@ public class Knockback3
 
 
 	/**
-		Stop tracking unit u.  If the unit is middair it will simply stop moving.  If the unit is already untracked,
+		Stop tracking unit u. If the unit is middair it will simply stop moving. If the unit is already untracked,
 		nothing happens.
 	*/
 	static function forget(unit u)
@@ -265,10 +265,10 @@ public class Knockback3
 			if velXySquared > destroyDestructableSpeedThreshold * ANIMATION_PERIOD and pos3.z < destroyDestructableHeightThreshold
 				tickTryDestructable(knockback, newPos3)
 
-			let is_vel_xy_low = velXySquared < (minimumSlideSpeed * minimumSlideSpeed) * ANIMATION_PERIOD
-			let is_vel_z_low = knockback.del.z.abs() < -1. * elasticityThreshold * ANIMATION_PERIOD
-			let is_airborne = pos3.z > isAirborneThreshold
-			if is_vel_xy_low and is_vel_z_low and not is_airborne
+			let isVelxyLow = velXySquared < (minimumSlideSpeed * minimumSlideSpeed) * ANIMATION_PERIOD
+			let isVelzLow = knockback.del.z.abs() < -1. * elasticityThreshold * ANIMATION_PERIOD
+			let isAirborne = pos3.z > isAirborneThreshold
+			if isVelxyLow and isVelzLow and not isAirborne
 				knockback.u.setFlyHeight(0., 0.)
 				destroy knockback
 


### PR DESCRIPTION
- Add `forget` to the API to remove a unit from Knockback3 control
- Move some cleanup behavior into an ondestroy
- Slightly simplify elasticity check