### PR TITLE
Added setter for the maxStack item field

### DIFF
--- a/wurst/objediting/ItemObjEditing.wurst
+++ b/wurst/objediting/ItemObjEditing.wurst
@@ -141,3 +141,6 @@ public class ItemDefinition extends W3TDefinition
 
 	function setInterfaceIcon(string data)
 		def.setString("iico", data)
+
+	function setMaxStack(int data)
+		def.setInt("ista", data)


### PR DESCRIPTION
Reforged added a field to the item object definition allowing us to set the number of stack for an item

![](https://i.gyazo.com/bf26a87a9ff0cbe42ab27c452bd8565c.png)