### PR TITLE
Hotfix ChunkedString

### DIFF
--- a/wurst/file/ChunkedString.wurst
+++ b/wurst/file/ChunkedString.wurst
@@ -52,7 +52,7 @@ public class ChunkedString
 			chunkCount++
 
 	function hasChunk() returns boolean
-		return readIndex < chunkCount
+		return readIndex + 1 < chunkCount
 
 	function readChunk() returns string
 		readIndex++

--- a/wurst/file/ChunkedString.wurst
+++ b/wurst/file/ChunkedString.wurst
@@ -52,7 +52,7 @@ public class ChunkedString
 			chunkCount++
 
 	function hasChunk() returns boolean
-		return readIndex + 1 < chunkCount
+		return readIndex + 1 < chunkCount or buffer.length() > 0
 
 	function readChunk() returns string
 		readIndex++

--- a/wurst/file/ChunkedString.wurst
+++ b/wurst/file/ChunkedString.wurst
@@ -52,7 +52,7 @@ public class ChunkedString
 			chunkCount++
 
 	function hasChunk() returns boolean
-		return readIndex + 1 < chunkCount or buffer.length() > 0
+		return readIndex + 1 < chunkCount or (readIndex + 1 == chunkCount and buffer.length() > 0)
 
 	function readChunk() returns string
 		readIndex++


### PR DESCRIPTION
readIndex is -1 by default, and chunkCount is 0 by default, so an empty ChunkedString returns true on hasChunk.