### PR TITLE
Fix reading empty files

### DIFF
--- a/wurst/file/SaveLoadData.wurst
+++ b/wurst/file/SaveLoadData.wurst
@@ -70,7 +70,7 @@ public function player.loadData(string slotName, LoadListener listener)
 	file.close()
 
 	buffer.sync(this) (syncedBuffer) ->
-		if not syncedBuffer.hasChunk()
+		if syncedBuffer.length() == 0
 			listener.onLoad(LoadStatus.FAIL_FILE_EMPTY, syncedBuffer)
 		else if syncedBuffer.readChunk() == "-"
 			listener.onLoad(LoadStatus.FAIL_CANT_READ, syncedBuffer)


### PR DESCRIPTION
Even an empty ChunkedString has one (empty) chunk, so you should check it's length instead of checking whether it has a chunk.