### PR TITLE
Add option to autopreset normal tooltips

### DIFF
--- a/wurst/objediting/AbilityObjEditing.wurst
+++ b/wurst/objediting/AbilityObjEditing.wurst
@@ -14,6 +14,8 @@ import Annotations
 	property names to have spaces. */
 @configurable constant USE_PROPERTY_SPACING = true
 
+@configurable constant PRESET_NORMAL_TOOLTIPS_AUTOMATICALLY = false
+
 public enum AllowWhenFull
 	NEVER
 	LIFE_ONLY
@@ -62,6 +64,9 @@ public class AbilityDefinition
 	protected int newId
 	protected int baseId
 
+	private var name = ""
+	private var presetTooltipNormalAutomatically = PRESET_NORMAL_TOOLTIPS_AUTOMATICALLY
+
 	function getNewId() returns int
 		return newId
 
@@ -82,6 +87,16 @@ public class AbilityDefinition
 		this.lvls = lvls
 		def = createObjectDefinition("w3a", newId, baseId)
 		setLevels(lvls)
+
+	private function autoPresetTooltipNormal()
+		if presetTooltipNormalAutomatically
+			presetTooltipNormal(lvls > 1 ? (int lvl) -> "{0} - [|cFFFFCC00Level {1}|r]".format(name, lvl.toString()) : (int lvl) -> name)
+
+	function presetTooltipNormalAutomatically(bool preset)
+		presetTooltipNormalAutomatically = preset
+
+	function presetTooltipNormalAutomatically()
+		presetTooltipNormalAutomatically(true)
 
 	function addTooltipProperty(string pName, StringLevelClosure lc)
 		if tooltipGen != null and listen
@@ -117,7 +132,9 @@ public class AbilityDefinition
 
 	function setName(string value)
 		def.setLvlDataString("anam", 0, 0, value)
+		name = value
 		addTooltipProperty("Name", (int lvl) -> value)
+		autoPresetTooltipNormal()
 
 	function setEditorSuffix(string value)
 		def.setLvlDataString("ansf", 0, 0, value)
@@ -338,6 +355,7 @@ public class AbilityDefinition
 		def.setLvlDataInt("alev", 0, 0, value)
 		lvls = value
 		addTooltipProperty("Levels", (int lvl) -> value)
+		autoPresetTooltipNormal()
 
 	function setRequiredLevel(int value)
 		def.setLvlDataInt("arlv", 0, 0, value)


### PR DESCRIPTION
When making a lot of custom spells, especially based on standard ones, it's very annoying to set the normal tooltip similar to standard one by hands for each ability. It's also annoying to register a tooltip generator, start and stop listening just for normal tooltip... Since the extended one is done by hands if you want to follow the standard format. This adds an option to just make normal tooltips for all spells which look exactly like the standard one automatically, without having need to call any special methods.