### PR TITLE
Don't require lvl in buffs editing

### DIFF
--- a/wurst/objediting/BuffObjEditing.wurst
+++ b/wurst/objediting/BuffObjEditing.wurst
@@ -155,4 +155,77 @@ public class BuffDefinition
 	function setEffectSoundLooping(int level, string value)
 		def.setLvlDataString("fefl",  level, 0,  value)
 
+	function setName(string value)
+		setName(1, value)
 
+	function setEditorSuffix(string value)
+		setEditorSuffix(1, value)
+
+	function setRace(string value)
+		setRace(1, value)
+
+	function setCaster(string value)
+		setCaster(1, value)
+
+	function setArtTarget(string value)
+		setArtTarget(1, value)
+
+	function setArtSpecial(string value)
+		setArtSpecial(1, value)
+
+	function setEffect(string value)
+		setEffect(1, value)
+
+	function setAreaEffect(string value)
+		setAreaEffect(1, value)
+
+	function setMissileArt(string value)
+		setMissileArt(1, value)
+
+	function setMissileSpeed(int value)
+		setMissileSpeed(1, value)
+
+	function setMissileArc(real value)
+		setMissileArc(1, value)
+
+	function setMissileHomingEnabled(boolean value)
+		setMissileHomingEnabled(1, value)
+
+	function setTargetAttachments(int value)
+		setTargetAttachments(1, value)
+
+	function setTargetAttachmentPoint0(string value)
+		setTargetAttachmentPoint0(1, value)
+
+	function setTargetAttachmentPoint1(string value)
+		setTargetAttachmentPoint1(1, value)
+
+	function setTargetAttachmentPoint2(string value)
+		setTargetAttachmentPoint2(1, value)
+
+	function setTargetAttachmentPoint3(string value)
+		setTargetAttachmentPoint3(1, value)
+
+	function setTargetAttachmentPoint4(string value)
+		setTargetAttachmentPoint4(1, value)
+
+	function setTargetAttachmentPoint5(string value)
+		setTargetAttachmentPoint5(1, value)
+
+	function setCasterAttachments(int value)
+		setCasterAttachments(1, value)
+
+	function setSpecialAttachmentPoint(string value)
+		setSpecialAttachmentPoint(1, value)
+
+	function setTooltipNormal(string value)
+		setTooltipNormal(1, value)
+
+	function setTooltipNormalExtended(string value)
+		setTooltipNormalExtended(1, value)
+
+	function setEffectSound(string value)
+		setEffectSound(1, value)
+
+	function setEffectSoundLooping(string value)
+		setEffectSoundLooping(1, value)


### PR DESCRIPTION
In fact, buffs' parameters do not depend on levels. You cannot specify levels of a buff and it only uses it's level 1's parameters, so it's stupid to have to specify the level every time. This PR provides additional convenience overloads.