### PR TITLE
[HOTFIX] Reading from a ByteBuffer with a while loop

### DIFF
--- a/wurst/file/ByteBuffer.wurst
+++ b/wurst/file/ByteBuffer.wurst
@@ -22,7 +22,7 @@ public class ByteBuffer
 	private var readBuffer = 0
 	private var readBufferIndex = 4
 
-	private var readIndex = 0
+	private var readIndex = -1
 
 	ondestroy
 		destroy storage
@@ -73,8 +73,8 @@ public class ByteBuffer
 	/** Reads a single unsigned byte from this buffer. The returned value will be in the range [0, 255]. **/
 	function readByte() returns int
 		if readBufferIndex == 4
-			readBuffer = readIndex < intCount ? storage.loadInt(readIndex) : buffer
 			readIndex++
+			readBuffer = readIndex < intCount ? storage.loadInt(readIndex) : buffer
 			readBufferIndex = 0
 		let byte = selectByte(readBuffer, readBufferIndex)
 		readBufferIndex++
@@ -90,7 +90,7 @@ public class ByteBuffer
 
 	function resetRead()
 		readBufferIndex = 4
-		readIndex = 0
+		readIndex = -1
 
 	function getInt(int i) returns int
 		if i == intCount

--- a/wurst/file/ByteBuffer.wurst
+++ b/wurst/file/ByteBuffer.wurst
@@ -152,3 +152,21 @@ function byteBufferTest()
 	byteBuffer.readShort().assertEquals(0x002a)
 
 	byteBuffer.readInt().assertEquals(0xffaabbcc)
+
+@Test
+function byteBufferIterativeReadingTest()
+	let byteBuffer = new ByteBuffer()
+
+	let expectedBytes = [0xb3, 0xfb, 0xc6, 0xec, 0x89, 0xf9, 0x25, 0x22, 0x4a, 0xe0, 0x99, 0x08, 0x5d, 0x1a]
+	for i = 0 to expectedBytes.length - 1
+		byteBuffer.writeByte(expectedBytes[i])
+
+	int array bytes
+	var bytesLength = 0
+	while byteBuffer.hasByte()
+		bytes[bytesLength] = byteBuffer.readByte()
+		bytesLength++
+
+	bytesLength.assertEquals(expectedBytes.length)
+	for i = 0 to bytesLength - 1
+		bytes[i].assertEquals(expectedBytes[i])


### PR DESCRIPTION
I'm sorry for the bug I've missed when submitted the ByteBuffer. :S Here is the fix. Without it, reading from it in a while loop with hasByte() condition works wrong: you could miss some bytes.