### PR TITLE
Updated Trollbatrider soundset

### DIFF
--- a/wurst/_wurst/assets/Soundsets.wurst
+++ b/wurst/_wurst/assets/Soundsets.wurst
@@ -34,7 +34,7 @@ public class Soundsets
 	static constant bansheeGhost			= "BansheeGhost" // Only us
 	static constant bansheeRanger		   = "BansheeRanger" // Only us
 	static constant barrowDens			  = "BarrowDens" // BarrowDen in theirs
-	static constant batTroll				= "BatTroll" // Only us
+	static constant batTroll				= "TrollBatrider" // Only us
 	static constant bearDen				 = "BearDen"
 	static constant beastiary			   = "Beastiary"
 	static constant beastmaster			 = "Beastmaster"


### PR DESCRIPTION
Look like blizzard changed the string used to reference Troll batrider soundset.

![](https://i.imgur.com/CJqTL9j.png)