### PR TITLE
Removed superfluous variable in LinkedList.joinBy.

### DIFF
--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -547,15 +547,13 @@ public function group.asList() returns LinkedList<unit>
 /** Joins elements from a string list into one string using a separator */
 public function LinkedList<string>.joinBy(string separator) returns string
 	var joined = ""
-	var first = true
 	let iter = this.iterator()
 
 	for str from iter
-		if iter.hasNext() or not first
+		if iter.hasNext()
 			joined += str + separator
 		else
 			joined += str
-			first = false
 
 	iter.close()
 	return joined


### PR DESCRIPTION
This variable isn't needed. It's always `true` until after the if-condition is evaluated in the final step of the for-loop.