### PR TITLE
UnitObjEditing public import in HeroPreset

### DIFF
--- a/wurst/objediting/presets/HeroPreset.wurst
+++ b/wurst/objediting/presets/HeroPreset.wurst
@@ -1,5 +1,5 @@
 package HeroPreset
-import UnitObjEditing
+import public UnitObjEditing
 import LinkedList
 import ObjectIds
 


### PR DESCRIPTION
If you are using HeroPreset.wurst, you can't use stuff like TargetsAllowed or ArmorType and etc. which are publicly imported in UnitObjEditing.wurst. You have to import UnitObjEditing.wurst again or import TargetsAllowed.wurst and ObjEditingCommons.wurst separately.
This fix solves the problem.