### PR TITLE
[pre1.29] fix LinkedList.removeAt

### DIFF
--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -103,9 +103,10 @@ public class LinkedList<T>
 		let entry = getEntry(index)
 		entry.prev.next = entry.next
 		entry.next.prev = entry.prev
+		let res = entry.elem
 		destroy entry	
 		size--
-		return entry.elem
+		return res
 		
 	/** Removes the first occurence of t from this list */
 	function remove(T elem)


### PR DESCRIPTION
This problem can cause compilation failure, keep the same as the master branch.

https://github.com/wurstscript/WurstStdlib2/blob/master/wurst/data/LinkedList.wurst#L127