### PR TITLE
fix knockback3 getting stuck on cliffs

### DIFF
--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -186,7 +186,11 @@ public class Knockback3
 
 
 	private static function tickNearGround(Knockback3 knockback, vec3 newPos3, vec3 pos3, real velXySquared)
-		if newPos3.toVec2().isTerrainWalkable()
+		if (
+				newPos3.toVec2().isTerrainWalkable()
+				or (newPos3.z > HEIGHTMAP_PROVIDER.get(newPos3) and knockback.del.z > 0.)
+				or (not pos3.toVec2().isTerrainWalkable())
+		)
 			knockback.u.setXY(newPos3)
 
 			if knockback.del.z <= isAirborneThreshold
@@ -202,7 +206,7 @@ public class Knockback3
 				knockback.u.setPropWindow(knockback.u.getDefaultPropWindow() * bj_DEGTORAD)
 
 		else
-			knockback.del = knockback.del.project(vec3(0., 0., 1.))
+			knockback.del = knockback.del.rotate(vec3(0., 0., 1.), PI) * restitutionCoefficientGround
 
 		if knockback.del.z < elasticityThreshold * ANIMATION_PERIOD
 			knockback.del.z = knockback.del.z*-1.*restitutionCoefficientGround

--- a/wurst/util/Knockback3.wurst
+++ b/wurst/util/Knockback3.wurst
@@ -40,11 +40,25 @@ public interface TerrainZProvider
 public interface UnitFilter
 	function get(unit which) returns bool
 
+/** A vec3 -> vec3 closure. */
+public interface WallHitTransform
+	function apply(vec3 vel) returns vec3
+
 /**
 If configured, provides an alternative source for getting terrain z-height.
 This can be useful for avoiding a desync in some cases.
 */
 @configurable TerrainZProvider HEIGHTMAP_PROVIDER = (vec3 w) -> w.getTerrainZ()
+
+/**
+Controls the behavior when hitting a wall at low altitude. Default behavior is to bounce/reverse off the wall, applying
+the same restitution as in bouncing off the ground.
+
+Override this value if you want to prevent bouncing, reflect on planes, etc.
+*/
+@configurable WallHitTransform WALLHIT_TRANSFORM = (vec3 vel) -> (
+	vel.rotate(vec3(0., 0., 1.), PI) * Knockback3.restitutionCoefficientGround
+)
 
 /** The square rect size used for finding destructables. */
 @configurable let DESTRUCTABLE_ENUM_SIZE = 130.
@@ -206,7 +220,7 @@ public class Knockback3
 				knockback.u.setPropWindow(knockback.u.getDefaultPropWindow() * bj_DEGTORAD)
 
 		else
-			knockback.del = knockback.del.rotate(vec3(0., 0., 1.), PI) * restitutionCoefficientGround
+			knockback.del = WALLHIT_TRANSFORM.apply(knockback.del)
 
 		if knockback.del.z < elasticityThreshold * ANIMATION_PERIOD
 			knockback.del.z = knockback.del.z*-1.*restitutionCoefficientGround


### PR DESCRIPTION
Closes #383

See https://github.com/Cokemonkey11/knockback3-demo/ for demo map

Knockback3 behaves poorly when a unit ends up on a cliff edge (gets stuck).

This PR improves the behavior in a few ways:

- A unit is no longer considered to have hit a wall in the following cases:
    * The unit is ascending and the next tick puts the unit at higher Z than the terrain
    * The units current position before next tick is not walkable
- When a unit strikes a wall, instead of losing all horizontal velocity, the unit bounces, knocking in the opposite direction. Friction applies as in the bouncing off the ground case.

It is still possible to get stuck on cliffs (!) but this PR makes it significantly easier to get un-stuck.