### PR TITLE
Fixed loadData not checking for extension

### DIFF
--- a/wurst/file/SaveLoadData.wurst
+++ b/wurst/file/SaveLoadData.wurst
@@ -65,7 +65,7 @@ public function player.loadData(string slotName, LoadListener listener)
 		listener.onLoad(LoadStatus.FAIL_PLAYER_OFFLINE, null)
 		return
 
-	let file = new File(slotName)
+	let file = new File(slotName.endsWith(".pld") ? slotName : slotName + ".pld")
 	let buffer = file.read(this)
 	file.close()
 


### PR DESCRIPTION
Because of that you can't load file with just passing file name like "myFileName".
Wurst SaveLoadData package docs and website examples were using it without extension too, so it was confusing at first why it wasn't working.