### PR TITLE
Group API

### DIFF
--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -74,7 +74,7 @@ public function group.destr()
 public function group.has(unit u) returns bool
 	return IsUnitInGroup(u, this)
 
-@deprecated("Use .has insted.")
+@deprecated("Use .has instead.")
 public function group.contains(unit u) returns bool
 	return this.has(u)
 
@@ -92,7 +92,7 @@ public function group.getRandom() returns unit
 		return this.get(GetRandomInt(0, size - 1))
 	return null
 
-@deprecated("Use .getRandom insted.")
+@deprecated("Use .getRandom instead.")
 public function group.getRandomUnit() returns unit
 	return this.getRandom()
 

--- a/wurst/_handles/Group.wurst
+++ b/wurst/_handles/Group.wurst
@@ -2,6 +2,7 @@ package Group
 import NoWurst
 import Vectors
 import Player
+import Annotations
 
 /** Use this group for your non-nested group enum calls
 	and then iterate through the group via **for from** or
@@ -35,73 +36,110 @@ public function group.enumUnitsOfType(int id, boolexpr filter)
 public function group.enumUnitsAll(boolexpr filter)
 	for i = 0 to bj_MAX_PLAYER_SLOTS - 1
 		ENUM_GROUP.enumUnitsOfPlayer(players[i], filter)
-		this.addGroup(ENUM_GROUP)
+		this.add(ENUM_GROUP)
 	ENUM_GROUP.clear()
 
 public function group.clear()
 	GroupClear(this)
 
+/** Returns the number of added units. */
+public function group.add(vararg unit units) returns int
+	var i = 0
+	for u in units
+		if GroupAddUnit(this, u)
+			i += 1
+	return i
+
+@deprecated("Use .add instead.")
 public function group.addUnit(vararg unit units)
 	for u in units
-		GroupAddUnit(this, u)
+		this.add(u)
 
+/** Retruns the number of removed units. */
+public function group.remove(vararg unit units) returns int
+	var i = 0
+	for u in units
+		if GroupRemoveUnit(this, u)
+			i += 1
+	return i
+
+@deprecated("Use .remove instead.")
 public function group.removeUnit(vararg unit units)
 	for u in units
-		GroupRemoveUnit(this, u)
+		this.remove(u)
 
 public function group.destr()
 	DestroyGroup(this)
 
-public function group.contains(unit u) returns boolean
+public function group.has(unit u) returns bool
 	return IsUnitInGroup(u, this)
+
+@deprecated("Use .has insted.")
+public function group.contains(unit u) returns bool
+	return this.has(u)
 
 public function group.size() returns int
 	return BlzGroupGetSize(this)
 
-public function group.isEmpty() returns boolean
+public function group.isEmpty() returns bool
 	return not this.hasNext()
 
-var randomCounter = 0
-unit randomSelected = null
 /** Returns a random unit from this group without removing it
 	or null if the group is empty */
-public function group.getRandomUnit() returns unit
+public function group.getRandom() returns unit
 	let size = this.size()
-	randomCounter = 1 + GetRandomInt(0, size - 1)
-	randomSelected = null
-	ForGroup(this) ->
-		randomCounter--
-		if randomCounter == 0
-			randomSelected = GetEnumUnit()
+	if size > 0
+		return this.get(GetRandomInt(0, size - 1))
+	return null
 
-	return randomSelected
+@deprecated("Use .getRandom insted.")
+public function group.getRandomUnit() returns unit
+	return this.getRandom()
 
-public function group.immediateOrder(string order) returns boolean
+public function group.immediateOrder(string order) returns bool
 	return GroupImmediateOrder(this, order)
 
-public function group.immediateOrderById(int order) returns boolean
+public function group.immediateOrderById(int order) returns bool
 	return GroupImmediateOrderById(this, order)
 
-public function group.pointOrder(string order, vec2 point) returns boolean
+public function group.pointOrder(string order, vec2 point) returns bool
 	return GroupPointOrder(this, order, point.x, point.y)
 
-public function group.pointOrderById(int order, vec2 point) returns boolean
+public function group.pointOrderById(int order, vec2 point) returns bool
 	return GroupPointOrderById(this, order, point.x, point.y)
 
-public function group.targetOrder(string order, widget targetWidget) returns boolean
+public function group.targetOrder(string order, widget targetWidget) returns bool
 	return GroupTargetOrder(this, order, targetWidget)
 
-public function group.targetOrder(int order, widget targetWidget) returns boolean
+public function group.targetOrder(int order, widget targetWidget) returns bool
 	return GroupTargetOrderById(this, order, targetWidget)
 
+public function group.add(vararg group groups) returns int
+	var i = 0
+	for g in groups
+		i += BlzGroupAddGroupFast(g, this)
+	return i
+
+@deprecated("Use .add instead.")
 public function group.addGroup(group g) returns int
-	return BlzGroupAddGroupFast(g, this)
+	return this.add(g)
 
+public function group.remove(vararg group groups) returns int
+	var i = 0
+	for g in groups
+		i += BlzGroupRemoveGroupFast(g, this)
+	return i
+
+@deprecated("Use .remove instead.")
 public function group.removeGroup(group g) returns int
-	return BlzGroupRemoveGroupFast(g, this)
+	return this.remove(g)
 
-public function group.getUnitAt(int index) returns unit
+public function group.get(int index) returns unit
 	return BlzGroupUnitAt(this, index)
+
+@deprecated("Use .get instead.")
+public function group.getUnitAt(int index) returns unit
+	return this.get(index)
 
 /* Group iterator */
 
@@ -110,11 +148,11 @@ group iterGroup
 /** Creates a new iterator for this group. */
 public function group.iterator() returns group
 	iterGroup = CreateGroup()
-	ForGroup(this, () -> iterGroup.addUnit(GetEnumUnit()))
+	ForGroup(this, () -> iterGroup.add(GetEnumUnit()))
 	return iterGroup
 
 /** Returns whether the iterator has the next item */
-public function group.hasNext() returns boolean
+public function group.hasNext() returns bool
 	return FirstOfGroup(this) != null
 
 /** Returns the next item from the iterator */

--- a/wurst/_handles/GroupTests.wurst
+++ b/wurst/_handles/GroupTests.wurst
@@ -9,7 +9,7 @@ function testGroupBasic()
 	let u = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
 	assertTrue(u != null)
 	g.add(u)
-	assertTrue(g.size() == 1)
+	g.size().assertEquals(1)
 
 	var count = 0
 
@@ -22,7 +22,7 @@ function testGroupBasic()
 	let u2 = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
 	g.add(u2)
 	assertTrue(g.get(0) == u)
-	assertTrue(g.size() == 12)
+	g.size().assertEquals(12)
 	assertTrue(g.get(g.size()-1) == u2)
 
 	for int i = 0 to g.size()-1
@@ -110,7 +110,7 @@ function testVararg()
 	..add(units[4], units[5], units[6], units[7], units[8], units[9])
 
 	_count = g.add(a)
-	assertTrue(_count == a.size())
+	_count.assertEquals(a.size())
 
 	_count = g.add(b)
 	_count.assertEquals(4)

--- a/wurst/_handles/GroupTests.wurst
+++ b/wurst/_handles/GroupTests.wurst
@@ -8,28 +8,31 @@ function testGroupBasic()
 
 	let u = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
 	assertTrue(u != null)
-	g.addUnit(u)
-
+	g.add(u)
 	assertTrue(g.size() == 1)
+
+	var count = 0
+
 	for i = 1 to 10
-		g.addUnit(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
+		count += g.add(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
 
 	assertTrue(g.size() == 11)
-
+	assertTrue(count == 10)
 
 	let u2 = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
-	g.addUnit(u2)
-	assertTrue(g.getUnitAt(0) == u)
+	g.add(u2)
+	assertTrue(g.get(0) == u)
 	assertTrue(g.size() == 12)
-	assertTrue(g.getUnitAt(g.size()-1) == u2)
+	assertTrue(g.get(g.size()-1) == u2)
 
 	for int i = 0 to g.size()-1
-		print(g.getUnitAt(i).getHandleId())
+		print(g.get(i).getHandleId())
 	print("---")
 	print(u2.getHandleId())
 
 	g.clear()
 	assertTrue(g.isEmpty())
+
 
 @Test
 function testGroupForLoops()
@@ -37,7 +40,7 @@ function testGroupForLoops()
 	assertTrue(g != null)
 	assertTrue(not g.hasNext())
 	for i = 0 to 10
-		g.addUnit(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
+		g.add(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
 
 	assertTrue(g.hasNext())
 
@@ -54,18 +57,18 @@ function testRandom()
 	let g = CreateGroup()
 
 	for i = 0 to 10
-		g.addUnit(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
+		g.add(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
 
-	let ru = g.getRandomUnit()
+	let ru = g.getRandom()
 
 	assertTrue(ru != null)
 
-	assertTrue(g.contains(ru))
+	assertTrue(g.has(ru))
 
-	g.removeUnit(ru)
+	g.remove(ru)
 
 	for i = 1 to 10
-		g.removeUnit(g.getRandomUnit())
+		g.remove(g.getRandom())
 
 	assertTrue(g.isEmpty())
 
@@ -82,8 +85,46 @@ function testHandleId()
 @Test
 function testVararg()
 	let g = CreateGroup()
-	g.addUnit(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()), createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()), createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
+	g.add(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()), createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()), createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
 	g.size().assertEquals(3)
+
+	unit array units
+	var _count = 0
+
+	for i = 0 to 9
+		units[i] = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
+
+	g.clear()
+
+	_count = g.add(units[0], units[1], units[2], units[3])
+	assertTrue(_count == 4)
+
+	_count += g.add(units[2], units[3], units[4], units[5])
+	assertTrue(_count == 6)
+
+	g.clear()
+
+	let a = CreateGroup()
+	..add(units[0], units[1], units[2], units[3], units[4], units[5])
+	let b = CreateGroup()
+	..add(units[4], units[5], units[6], units[7], units[8], units[9])
+
+	_count = g.add(a)
+	assertTrue(_count == a.size())
+
+	_count = g.add(b)
+	assertTrue(_count == 4)
+
+	g.clear()
+	_count = g.add(a, b)
+	assertTrue(_count == 10)
+
+	_count = g.remove(units[0], units[1], units[2])
+	assertTrue(_count == 3)
+
+	_count = g.remove(a, b)
+	assertTrue(_count == 7)
+	assertTrue(g.isEmpty())
 
 @Test
 function testGroupForGroups()
@@ -92,17 +133,17 @@ function testGroupForGroups()
 	let u3 = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
 
 	let g = CreateGroup()
-	g.addUnit(u, u2)
+	g.add(u, u2)
 	g.size().assertEquals(2)
 
 	let g2 = CreateGroup()
-	g2.addGroup(g)
+	g2.add(g)
 	g2.size().assertEquals(g.size())
-	g2.contains(u).assertTrue()
+	g2.has(u).assertTrue()
 
-	g2.addUnit(u3)
-	g2.removeGroup(g)
+	g2.add(u3)
+	g2.remove(g)
 	g2.size().assertEquals(1)
-	g2.contains(u3).assertTrue()
-	g2.contains(u2).assertFalse()
-	g2.contains(u).assertFalse()
+	g2.has(u3).assertTrue()
+	g2.has(u2).assertFalse()
+	g2.has(u).assertFalse()

--- a/wurst/_handles/GroupTests.wurst
+++ b/wurst/_handles/GroupTests.wurst
@@ -16,8 +16,8 @@ function testGroupBasic()
 	for i = 1 to 10
 		count += g.add(createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg()))
 
-	assertTrue(g.size() == 11)
-	assertTrue(count == 10)
+	g.size().assertEquals(11)
+	count.assertEquals(10)
 
 	let u2 = createUnit(Player(0), 'hfoo', vec2(0, 0), 0 .fromDeg())
 	g.add(u2)
@@ -97,10 +97,10 @@ function testVararg()
 	g.clear()
 
 	_count = g.add(units[0], units[1], units[2], units[3])
-	assertTrue(_count == 4)
+	_count.assertEquals(4)
 
 	_count += g.add(units[2], units[3], units[4], units[5])
-	assertTrue(_count == 6)
+	_count.assertEquals(6)
 
 	g.clear()
 
@@ -113,17 +113,17 @@ function testVararg()
 	assertTrue(_count == a.size())
 
 	_count = g.add(b)
-	assertTrue(_count == 4)
+	_count.assertEquals(4)
 
 	g.clear()
 	_count = g.add(a, b)
-	assertTrue(_count == 10)
+	_count.assertEquals(10)
 
 	_count = g.remove(units[0], units[1], units[2])
-	assertTrue(_count == 3)
+	_count.assertEquals(3)
 
 	_count = g.remove(a, b)
-	assertTrue(_count == 7)
+	_count.assertEquals(7)
 	assertTrue(g.isEmpty())
 
 @Test

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -69,7 +69,7 @@ group iterGroup
 
 public function group.recyclableIterator() returns group
 	iterGroup = getGroup()
-	ForGroup(this, () -> iterGroup.addUnit(GetEnumUnit()))
+	ForGroup(this, () -> iterGroup.add(GetEnumUnit()))
 	return iterGroup
 
 /* Group instantiation */

--- a/wurst/util/Preloader.wurst
+++ b/wurst/util/Preloader.wurst
@@ -38,7 +38,7 @@ public function preloadUnit(vararg int unitIds) returns boolean
 	var valid = true
 	for unitId in unitIds
 		let u = createUnit(DUMMY_PLAYER, unitId, vec2(0,0), angle(0))
-		dumg.addUnit(u)
+		dumg.add(u)
 		valid = valid and u.isAlive()
 	return valid
 


### PR DESCRIPTION
API changes:

```
.addUnit(unit) -> .add(vararg unit)
.addGroup(group) -> .add(vararg group)
.removeUnit(unit) -> .remove(vararg unit)
.removeGroup(group) -> .remove(vararg group)
.contains(unit) -> .has(unit)
.getUnitAtIndex(int index) -> .get(int index)
.getRandomUnit() -> .getRandom() // the body is rewritten with .get
```

Cosmetic:
```
boolean -> bool
integer -> int
```