### PR TITLE
Public import for Icons.wurst in ChannelAbilityPreset

### DIFF
--- a/wurst/file/SaveLoadData.wurst
+++ b/wurst/file/SaveLoadData.wurst
@@ -65,7 +65,7 @@ public function player.loadData(string slotName, LoadListener listener)
 		listener.onLoad(LoadStatus.FAIL_PLAYER_OFFLINE, null)
 		return
 
-	let file = new File(slotName)
+	let file = new File(slotName.endsWith(".pld") ? slotName : slotName + ".pld")
 	let buffer = file.read(this)
 	file.close()
 

--- a/wurst/objediting/presets/ChannelAbilityPreset.wurst
+++ b/wurst/objediting/presets/ChannelAbilityPreset.wurst
@@ -3,6 +3,7 @@ import NoWurst
 import public AbilityObjEditing
 import public ObjectIds
 import public ObjectIdGenerator
+import public Icons
 import OrderStringFactory
 import BitSet
 import Annotations


### PR DESCRIPTION
If you use channel ability preset package, then you will most likely want to set an icon, since you don't wanna use std one.

This change will remove need in redundant Icons.wurst imports in every ability package, which use ChannelAbilityPreset.