### PR TITLE
Added getUnitIcon method

### DIFF
--- a/wurst/_handles/Unit.wurst
+++ b/wurst/_handles/Unit.wurst
@@ -9,6 +9,12 @@ public native UnitAlive(unit id) returns boolean
 public native GetUnitGoldCost(int unitid) returns int
 public native GetUnitWoodCost(int unitid) returns int
 
+public function getUnitIcon(int unitId) returns string
+    return BlzGetAbilityIcon(unitId)
+
+public function unit.getIcon() returns string
+    return getUnitIcon(this.getTypeId())
+	
 public function unit.getGoldCost() returns int
 	return GetUnitGoldCost(this.getTypeId())
 


### PR DESCRIPTION
I didn't know it was possible to retrieve a unit icon, then I saw [this hive workshop comment](https://www.hiveworkshop.com/threads/still-no-natives-to-get-unit-type-icons-etc.337444/#post-3516994), I thought adding this method would be useful, at least to know that it's possible.