### PR TITLE
Add tests for mocked Quest and Quest Item handles.

### DIFF
--- a/wurst/_handles/QuestItemTests.wurst
+++ b/wurst/_handles/QuestItemTests.wurst
@@ -1,0 +1,22 @@
+package QuestItemTests
+import NoWurst
+import QuestItem
+import Wurstunit
+
+@test function testComplete()
+    let qi = new QuestItem(CreateQuest(), "")
+    qi.isCompleted().assertFalse()
+
+    qi.complete(true)
+    qi.isCompleted().assertTrue()
+
+    qi.complete(false)
+    qi.isCompleted().assertFalse()
+
+@test function testQuestItemNatives()
+    // Exercise mocked out quest item native.
+    // There's currently no way to validate the behavior of this native,
+    // but this will detect a regression in mocked native presence.
+    let qi = QuestCreateItem(CreateQuest())
+
+    qi.setDescription("")

--- a/wurst/_handles/QuestTests.wurst
+++ b/wurst/_handles/QuestTests.wurst
@@ -1,0 +1,46 @@
+package QuestTests
+import NoWurst
+import Quest
+import Wurstunit
+
+function QuestState.toString() returns string
+    switch this
+        case FAILED
+            return "FAILED"
+        case COMPLETED
+            return "COMPLETED"
+        case UNDISCOVERED
+            return "UNDISCOVERED"
+        case DISCOVERED
+            return "DISCOVERED"
+        default
+            return "UNKNOWN"
+
+function QuestState.assertEquals(QuestState want)
+    if this != want
+        testFail("Expected <" + want.toString() + ">, Actual <" + this.toString() + ">")
+
+@test function testSetState()
+    let q = new Quest(false /* required */)
+    
+    q.setState(QuestState.COMPLETED)
+    q.getState().assertEquals(QuestState.COMPLETED)
+
+    q.setState(QuestState.FAILED)
+    q.getState().assertEquals(QuestState.FAILED)
+
+    q.setState(QuestState.UNDISCOVERED)
+    q.getState().assertEquals(QuestState.UNDISCOVERED)
+
+    q.setState(QuestState.DISCOVERED)
+    q.getState().assertEquals(QuestState.DISCOVERED)
+
+@test function testQuestNatives()
+    // Exercise mocked out quest natives.
+    // There's currently no way to validate the behavior of these natives,
+    // but this will detect a regression in mocked native presence.
+    let q = CreateQuest()
+    
+    q.setDescription("")
+    q.setIcon("")
+    q.setTitle("")


### PR DESCRIPTION
Add tests for the quest and quest item handles, leveraging the mocks added in https://github.com/wurstscript/WurstScript/pull/1060. Prefers testing through the Wurstscript handle implementations over the natives if possible.

Tried to base these on existing tests and the style guide, feedback is of course welcome!