### PR TITLE
Fixed Grom Hellscream soundset path

### DIFF
--- a/wurst/_wurst/assets/Soundsets.wurst
+++ b/wurst/_wurst/assets/Soundsets.wurst
@@ -145,7 +145,7 @@ public class Soundsets
 	static constant headHunter			  = "HeadHunter"
 	// >>>>> Here
 	static constant healingWard			 = "HealingWard" // Only us
-	static constant hellscream			  = "Hellscream" // Only us (Might be their Grom)
+	static constant hellscream			  = "Grom" // Only us (Might be their Grom)
 	static constant hermitCrab			  = "HermitCrab" // Only us
 	static constant heroArchMage			= "HeroArchMage"
 	// HeroAvatarMountainKing


### PR DESCRIPTION
On 1.36, "Hellscream" doesn't seem to exist.

![23-07-02-20-56-50](https://github.com/wurstscript/WurstStdlib2/assets/7768858/7e59d635-942f-4060-868f-9615181b83ab)

I didn't look for the reason as to why, but I remember some odd change about Hellscream name for reforged, maybe it's related?
https://us.forums.blizzard.com/en/warcraft3/t/why-do-we-hate-grom-now/14474
