### PR TITLE
Expose timer `getRemaining` API in `CallbackSingle`

### DIFF
--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -141,6 +141,9 @@ public abstract class CallbackSingle
 		cb.call()
 		destroy cb
 
+	function getRemaining() returns real
+		return t.getRemaining()
+
 	ondestroy
 		t.release()
 


### PR DESCRIPTION
I implemented a spell that has multiple charges, and an ability cooldown timer is displayed for each recharge time. I'm using `doAfter` to defer the recharge event, but I also need to update the remaining cooldown. All that to say, I need `CallbackSingle` to expose the `getRemaining()` API for its underlying timer.

Realized after my last PR that I've been using my WurstStdlib2 fork this whole time because of this 2-line change, so I figured I'd submit a PR for it.