### PR TITLE
Added setPortraitModelFile method

### DIFF
--- a/wurst/objediting/UnitObjEditing.wurst
+++ b/wurst/objediting/UnitObjEditing.wurst
@@ -246,6 +246,9 @@ public class UnitOrBuildingOrHeroDefinition extends W3UDefinition
 	function setModelFile(string data)
 		def.setString("umdl", data)
 
+	function setPortraitModelFile(string data)
+		def.setString("upor", data)
+
 	function setMinimumAttackRange(int data)
 		def.setInt("uamn", data)
 


### PR DESCRIPTION
The "upor" or "Art - Portrait Model File" field was added in the patch 2.0, it's a field used to set the portrait model, I believe its purpose is related to the new skin feature.

From what I am seeing, it's set to default for most standard editor units, if you make a new custom unit and change its model, you're going to have to change this portrait field too.