### PR TITLE
fix(LinkedList): null-safe LLIterator.reset()

### DIFF
--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -451,7 +451,7 @@ public class LLIterator<T>
 		this.destroyOnClose = destroyOnClose
 
 	function reset()
-		this.dummy   = parent.getDummy()
+		this.dummy   = parent != null ? parent.getDummy() : null
 		this.current = dummy
 
 	/** Removes from the list the last element that was returned by next() (optional operation).


### PR DESCRIPTION
## Summary

Adds a defensive null check to `LLIterator.reset()` to prevent a null-pointer crash when the iterator is constructed with a null parent.

## Problem

The `reset()` method is called from both `LLIterator` constructors (lines 446 and 450). If an iterator is ever constructed with a `null` parent, the current implementation crashes on line 454 when attempting to call `parent.getDummy()`.

## Solution

Changed line 454 from:
```wurst
this.dummy   = parent.getDummy()
```
to:
```wurst
this.dummy   = parent != null ? parent.getDummy() : null
```

This makes `reset()` defensive, allowing it to safely handle a null parent by setting `dummy` to null instead of crashing.

## Origin

This issue was discovered in production use by the [Twilight's Eve Reborn](https://github.com/code-fixxers/tever_main) Warcraft III map, which uses the WurstScript standard library extensively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)