### PR TITLE
fix typecheck warnings

### DIFF
--- a/wurst/StdlibIngameTests.wurst
+++ b/wurst/StdlibIngameTests.wurst
@@ -364,7 +364,7 @@ function testNestedZeroedDamage()
 	check(outerAmount > 1., "the outer hit kept its own amount (" + outerAmount.toString(1) + ")")
 	check(not DamageEvent.isFiring(), "no damage instance left on the stack")
 
-	note("DAMAGED fired " + reducedCalls.toString() + " time(s); zeroed nested hit "
+	note("DAMAGED fired " + reducedCalls + " time(s); zeroed nested hit "
 		+ (innerReducedFired ? "DID" : "did NOT") + " reach reduced listeners")
 
 	destroy ul
@@ -395,9 +395,9 @@ function testGroupNesting()
 			if nearest != null
 				innerCalls++
 
-	check(outerCount >= 4, "outer enumeration visited every unit (" + outerCount.toString() + ")")
+	check(outerCount >= 4, "outer enumeration visited every unit (" + outerCount + ")")
 	check(innerCalls == outerCount, "nested enumeration ran exactly once per outer unit ("
-		+ innerCalls.toString() + " vs " + outerCount.toString() + ")")
+		+ innerCalls + " vs " + outerCount + ")")
 
 	for i = 0 to 3
 		probes[i].remove()
@@ -421,7 +421,7 @@ function testTimedLoopStopBeforeStart()
 	probe.startTimedLoop()
 
 	doAfter(0.5) ->
-		check(probe.ticks > 0, "onTimedLoop runs after stop-then-start (ticks " + probe.ticks.toString() + ")")
+		check(probe.ticks > 0, "onTimedLoop runs after stop-then-start (ticks " + probe.ticks + ")")
 		probe.stopTimedLoopAndDestroy()
 
 function testTimedLoopDoubleStart()
@@ -433,7 +433,7 @@ function testTimedLoopDoubleStart()
 
 	doAfter(0.5) ->
 		check(tripled.ticks == single.ticks, "three starts tick as often as one ("
-			+ tripled.ticks.toString() + " vs " + single.ticks.toString() + ")")
+			+ tripled.ticks + " vs " + single.ticks + ")")
 		single.stopTimedLoopAndDestroy()
 		tripled.stopTimedLoopAndDestroy()
 
@@ -477,10 +477,10 @@ public function runStdlibIngameTests()
 		testTimedLoopDoubleStart()
 
 	doAfter(1.5) ->
-		print("|cff8888ff=== " + (checksRun - checksFailed).toString() + "/" + checksRun.toString()
+		print("|cff8888ff=== " + (checksRun - checksFailed) + "/" + checksRun
 			+ " checks passed ===|r")
 		if checksFailed > 0
-			print("|cffff4444" + checksFailed.toString() + " check(s) FAILED|r")
+			print("|cffff4444" + checksFailed + " check(s) FAILED|r")
 
 /** Registers "-stdlibtest" as a chat command that runs the suite. */
 public function registerStdlibIngameTestCommand()
@@ -495,3 +495,4 @@ init
 	doAfter(1.) ->
 		runStdlibIngameTests()
 	registerStdlibIngameTestCommand()
+

--- a/wurst/_handles/DestructableTests.wurst
+++ b/wurst/_handles/DestructableTests.wurst
@@ -1,6 +1,4 @@
 package DestructableTests
-import Destructable
-import Wurstunit
 
 @Test function testDestructables()
 	let destr = createDestructable(0, ZERO2, 0 .fromDeg(), 1, -1)

--- a/wurst/_handles/DialogTests.wurst
+++ b/wurst/_handles/DialogTests.wurst
@@ -1,6 +1,5 @@
 package DialogTests
 import Dialog
-import Wurstunit
 
 @Test function testDialog()
 	let dia = createDialog()

--- a/wurst/_handles/EffectTests.wurst
+++ b/wurst/_handles/EffectTests.wurst
@@ -1,6 +1,4 @@
 package EffectTests
-import Effect
-import Wurstunit
 
 @Test function testEffect()
 	let eff = addEffect("testPath", vec2(12,32))

--- a/wurst/_handles/Framehandle.wurst
+++ b/wurst/_handles/Framehandle.wurst
@@ -76,7 +76,7 @@ constant BLZ_FRAMENAME_MAXLENGTH    = 560
 /** Returns whether the frame name length is valid or not */
 function verifyFrameNameLength(string name) returns boolean
 	if name.length() > BLZ_FRAMENAME_MAXLENGTH
-		error("Trying to address frame with exceeding maximum frame name length (" + BLZ_FRAMENAME_MAXLENGTH.toString() + ") for: " + name)
+		error("Trying to address frame with exceeding maximum frame name length (" + BLZ_FRAMENAME_MAXLENGTH + ") for: " + name)
 		return false
 	return true
 
@@ -178,12 +178,12 @@ public function createGlueTextButton(string name, framehandle owner, string inhe
 /** Returns the named command button frame.
 	In WC3 1.32+, moving command buttons through origin frames can glitch, so the named frames are usually safer. */
 public function getCommandButton(int index) returns framehandle
-	return getFrame("CommandButton_" + index.toString(), 0)
+	return getFrame("CommandButton_" + index, 0)
 
 /** Returns the named inventory button frame.
 	In WC3 1.32+, moving item buttons through origin frames can glitch, so the named frames are usually safer. */
 public function getInventoryButton(int index) returns framehandle
-	return getFrame("InventoryButton_" + index.toString(), 0)
+	return getFrame("InventoryButton_" + index, 0)
 
 /** Destroys a frame.
 	Unsafe for most multiplayer UI because destroying frames can desync or destabilize frame state after save/load.
@@ -674,3 +674,4 @@ public function framehandle.getChildrenCount() returns int
 	The index must be in the range 0 <= index < getChildrenCount(). Out-of-bounds access can crash. */
 public function framehandle.getChild(int index) returns framehandle
 	return BlzFrameGetChild(this, index)
+

--- a/wurst/_handles/Player.wurst
+++ b/wurst/_handles/Player.wurst
@@ -1,7 +1,6 @@
 package Player
 import NoWurst
 import Unit
-import Annotations
 import String
 
 /** Use this array instead of Player() to avoid leaks */
@@ -10,7 +9,7 @@ public constant localPlayer = GetLocalPlayer()
 init
 	initPlayerArray()
 
-@compiletime function initPlayerArray()
+function initPlayerArray()
 	for i = 0 to bj_MAX_PLAYER_SLOTS - 1
 		players[i] = Player(i)
 

--- a/wurst/_handles/Player.wurst
+++ b/wurst/_handles/Player.wurst
@@ -1,6 +1,7 @@
 package Player
 import NoWurst
 import Unit
+import Annotations
 import String
 
 /** Use this array instead of Player() to avoid leaks */
@@ -9,7 +10,7 @@ public constant localPlayer = GetLocalPlayer()
 init
 	initPlayerArray()
 
-function initPlayerArray()
+@compiletime function initPlayerArray()
 	for i = 0 to bj_MAX_PLAYER_SLOTS - 1
 		players[i] = Player(i)
 

--- a/wurst/_handles/PlayerTests.wurst
+++ b/wurst/_handles/PlayerTests.wurst
@@ -1,6 +1,4 @@
 package PlayerTests
-import Player
-import Wurstunit
 
 @Test function testPlayer()
 	let p = Player(0)

--- a/wurst/_handles/Playercolor.wurst
+++ b/wurst/_handles/Playercolor.wurst
@@ -1,7 +1,6 @@
 package Playercolor
 import NoWurst
 import Force
-import Player
 
 public constant PLAYER_COLOR_BLACK_AGGRESSIVE = ConvertPlayerColor(24)
 public constant PLAYER_COLOR_UNKNOWN1 = ConvertPlayerColor(25)
@@ -59,15 +58,16 @@ public function playercolor.toInt() returns int
 /** Returns the player that had this color *at the start of the game*. Does not
 	respect SetPlayerColor. */
 public function playercolor.getPlayer() returns player
-	return players[this.toInt()]
+	return Player(this.toInt())
 
 /** Returns the players who are currently using this player color. Respects calls
 	to SetPlayerColor */
 public function playercolor.getPlayers() returns force
 	let matchingPlayers = CreateForce()
 	for i = 0 to bj_MAX_PLAYER_SLOTS - 1
-		if players[i].getColor() == this
-			matchingPlayers.addPlayer(players[i])
+		let currentPlayer = Player(i)
+		if currentPlayer.getColor() == this
+			matchingPlayers.addPlayer(currentPlayer)
 	return matchingPlayers
 
 

--- a/wurst/_handles/Playercolor.wurst
+++ b/wurst/_handles/Playercolor.wurst
@@ -1,6 +1,7 @@
 package Playercolor
 import NoWurst
 import Force
+import Player
 
 public constant PLAYER_COLOR_BLACK_AGGRESSIVE = ConvertPlayerColor(24)
 public constant PLAYER_COLOR_UNKNOWN1 = ConvertPlayerColor(25)
@@ -58,16 +59,15 @@ public function playercolor.toInt() returns int
 /** Returns the player that had this color *at the start of the game*. Does not
 	respect SetPlayerColor. */
 public function playercolor.getPlayer() returns player
-	return Player(this.toInt())
+	return players[this.toInt()]
 
 /** Returns the players who are currently using this player color. Respects calls
 	to SetPlayerColor */
 public function playercolor.getPlayers() returns force
 	let matchingPlayers = CreateForce()
 	for i = 0 to bj_MAX_PLAYER_SLOTS - 1
-		let currentPlayer = Player(i)
-		if currentPlayer.getColor() == this
-			matchingPlayers.addPlayer(currentPlayer)
+		if players[i].getColor() == this
+			matchingPlayers.addPlayer(players[i])
 	return matchingPlayers
 
 

--- a/wurst/_handles/PlayercolorTests.wurst
+++ b/wurst/_handles/PlayercolorTests.wurst
@@ -1,6 +1,4 @@
 package PlayercolorTests
-import Playercolor
-import Wurstunit
 
 @Test public function testToInt()
 	PLAYER_COLOR_RED.toInt().assertEquals(0)
@@ -16,20 +14,21 @@ import Wurstunit
 
 @Test public function testGetPlayers()
 	// Test some Player package methods that this file depends on
-	(players[0] != null).assertTrue()
-	players[0].setColor(PLAYER_COLOR_RED)
-	(players[0].getColor() == PLAYER_COLOR_RED).assertTrue()
+	let player0 = Player(0)
+	(player0 != null).assertTrue()
+	player0.setColor(PLAYER_COLOR_RED)
+	(player0.getColor() == PLAYER_COLOR_RED).assertTrue()
 	// Test getting forces of players.
 	let force1 = PLAYER_COLOR_RED.getPlayers()
 	force1.containsPlayer(Player(0)).assertTrue()
-	players[1].setColor(PLAYER_COLOR_BLUE)
-	players[2].setColor(PLAYER_COLOR_BLUE)
+	Player(1).setColor(PLAYER_COLOR_BLUE)
+	Player(2).setColor(PLAYER_COLOR_BLUE)
 	let force2 = PLAYER_COLOR_BLUE.getPlayers()
 	force2.containsPlayer(Player(1)).assertTrue()
 	force2.containsPlayer(Player(2)).assertTrue()
 	force2.containsPlayer(Player(3)).assertFalse()
 
-	let p = players[5]
+	let p = Player(5)
 	assertTrue(p.getColor() == null)
 	p.setColor(PLAYER_COLOR_AQUA)
 	assertTrue(p.getColor() == PLAYER_COLOR_AQUA)

--- a/wurst/_handles/PlayercolorTests.wurst
+++ b/wurst/_handles/PlayercolorTests.wurst
@@ -14,21 +14,20 @@ package PlayercolorTests
 
 @Test public function testGetPlayers()
 	// Test some Player package methods that this file depends on
-	let player0 = Player(0)
-	(player0 != null).assertTrue()
-	player0.setColor(PLAYER_COLOR_RED)
-	(player0.getColor() == PLAYER_COLOR_RED).assertTrue()
+	(players[0] != null).assertTrue()
+	players[0].setColor(PLAYER_COLOR_RED)
+	(players[0].getColor() == PLAYER_COLOR_RED).assertTrue()
 	// Test getting forces of players.
 	let force1 = PLAYER_COLOR_RED.getPlayers()
 	force1.containsPlayer(Player(0)).assertTrue()
-	Player(1).setColor(PLAYER_COLOR_BLUE)
-	Player(2).setColor(PLAYER_COLOR_BLUE)
+	players[1].setColor(PLAYER_COLOR_BLUE)
+	players[2].setColor(PLAYER_COLOR_BLUE)
 	let force2 = PLAYER_COLOR_BLUE.getPlayers()
 	force2.containsPlayer(Player(1)).assertTrue()
 	force2.containsPlayer(Player(2)).assertTrue()
 	force2.containsPlayer(Player(3)).assertFalse()
 
-	let p = Player(5)
+	let p = players[5]
 	assertTrue(p.getColor() == null)
 	p.setColor(PLAYER_COLOR_AQUA)
 	assertTrue(p.getColor() == PLAYER_COLOR_AQUA)

--- a/wurst/_handles/QuestTests.wurst
+++ b/wurst/_handles/QuestTests.wurst
@@ -18,7 +18,7 @@ function QuestState.toString() returns string
 
 function QuestState.assertEquals(QuestState want)
     if this != want
-        testFail("Expected <" + want.toString() + ">, Actual <" + this.toString() + ">")
+        testFail("Expected <" + want + ">, Actual <" + this + ">")
 
 @Test function testSetState()
     let q = new Quest(false /* required */)
@@ -44,3 +44,4 @@ function QuestState.assertEquals(QuestState want)
     q.setDescription("")
     q.setIcon("")
     q.setTitle("")
+

--- a/wurst/_handles/RectTests.wurst
+++ b/wurst/_handles/RectTests.wurst
@@ -1,6 +1,4 @@
 package RectTests
-import Rect
-import Wurstunit
 
 
 @Test

--- a/wurst/_handles/primitives/PrimitivesTests.wurst
+++ b/wurst/_handles/primitives/PrimitivesTests.wurst
@@ -46,7 +46,7 @@ function testBoolean()
 @Test
 function testArrayLength()
 	let _x = [1, 2, 3]
-	print("length: " + _x.length.toString())
+	print("length: " + _x.length)
 	_x.length.assertEquals(3)
 
 @Test
@@ -60,3 +60,4 @@ function testXor()
 	xor(true, false).assertEquals(true)
 	xor(false, true).assertEquals(true)
 	xor(false, false).assertEquals(false)
+

--- a/wurst/_handles/primitives/String.wurst
+++ b/wurst/_handles/primitives/String.wurst
@@ -365,7 +365,7 @@ public function string.format(vararg string replacements) returns string
 	var result = this
 	var i = 0
 	for replacement in replacements
-		result = result.replace("{" + i.toString() + "}", replacement)
+		result = result.replace("{" + i + "}", replacement)
 		i++
 	return result
 
@@ -445,5 +445,6 @@ public class StringLines
 @deprecated("Use string.split(\n) instead")
 public function string.toLines() returns StringLines
 	return new StringLines(this, 0, this.countOccurences("\n") + 1)
+
 
 

--- a/wurst/_wurst/Wurstunit.wurst
+++ b/wurst/_wurst/Wurstunit.wurst
@@ -19,35 +19,35 @@ import Annotations
  */
 public function int.assertEquals(int expected)
 	if this != expected
-		testFail("Expected <" + expected.toString() + ">, Actual <" + this.toString() + ">")
+		testFail("Expected <" + expected + ">, Actual <" + this + ">")
 
 /**
  * Asserts that the passed int is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function int.assertGreaterThan(int less)
 	if this <= less
-		testFail("Expected <" + this.toString() + "> to be greater than <" + less.toString() + ">")
+		testFail("Expected <" + this + "> to be greater than <" + less + ">")
 
 /**
  * Asserts that the passed int is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function int.assertGreaterThanOrEqual(int less)
 	if this < less
-		testFail("Expected <" + this.toString() + "> to be greater than or equal to <" + less.toString() + ">")
+		testFail("Expected <" + this + "> to be greater than or equal to <" + less + ">")
 
 /**
  * Asserts that the passed int is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function int.assertLessThan(int greater)
 	if this >= greater
-		testFail("Expected <" + this.toString() + "> to be less than <" + greater.toString() + ">")
+		testFail("Expected <" + this + "> to be less than <" + greater + ">")
 
 /**
  * Asserts that the passed int is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function int.assertLessThanOrEqual(int greater)
 	if this > greater
-		testFail("Expected <" + this.toString() + "> to be less than or equal to <" + greater.toString() + ">")
+		testFail("Expected <" + this + "> to be less than or equal to <" + greater + ">")
 
 /**
  * Asserts that two strings are equal. If they are not, an error is thrown with a message.
@@ -61,35 +61,35 @@ public function string.assertEquals(string expected)
  */
 public function real.assertEquals(real expected)
 	if this != expected
-		testFail("Expected <" + expected.toString() + ">, Actual <" + this.toString() + ">")
+		testFail("Expected <" + expected + ">, Actual <" + this + ">")
 
 /**
  * Asserts that the passed real is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function real.assertGreaterThan(real less)
 	if this <= less
-		testFail("Expected <" + this.toString() + "> to be greater than <" + less.toString() + ">")
+		testFail("Expected <" + this + "> to be greater than <" + less + ">")
 
 /**
  * Asserts that the passed real is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function real.assertGreaterThanOrEqual(real less)
 	if this < less
-		testFail("Expected <" + this.toString() + "> to be greater than or equal to <" + less.toString() + ">")
+		testFail("Expected <" + this + "> to be greater than or equal to <" + less + ">")
 
 /**
  * Asserts that the passed real is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function real.assertLessThan(real greater)
 	if this >= greater
-		testFail("Expected <" + this.toString() + "> to be less than <" + greater.toString() + ">")
+		testFail("Expected <" + this + "> to be less than <" + greater + ">")
 
 /**
  * Asserts that the passed real is greater than the parameter. If they are not, an error is thrown with a message.
  */
 public function real.assertLessThanOrEqual(real greater)
 	if this > greater
-		testFail("Expected <" + this.toString() + "> to be less than or equal to <" + greater.toString() + ">")
+		testFail("Expected <" + this + "> to be less than or equal to <" + greater + ">")
 
 /**
  * Asserts that two reals are equal to within a positive delta. If they are not, an error is thrown
@@ -97,14 +97,14 @@ public function real.assertLessThanOrEqual(real greater)
  */
 public function real.assertEquals(real expected, real delta)
 	if (this - expected).abs() > delta
-		testFail("Expected <" + expected.toString() + ">, Actual <" + this.toString() + " with delta " + delta.toString() + ">")
+		testFail("Expected <" + expected + ">, Actual <" + this + " with delta " + delta + ">")
 
 /**
  * Asserts that two booleans are equal. If they are not, an error is thrown with a message.
  */
 public function boolean.assertEquals(boolean expected)
 	if this != expected
-		testFail("Expected <" + expected.toString() + ">, Actual <" + this.toString() + ">")
+		testFail("Expected <" + expected + ">, Actual <" + this + ">")
 
 /** Asserts that this booleans is true. If it is not, an error is thrown with a message. */
 public function boolean.assertTrue()
@@ -128,3 +128,4 @@ public function assertTrue(boolean b, string msg)
 public function assertNotNull<T>(T t)
 	if t == null
 		testFail("Assertion failed: Reference was null.")
+

--- a/wurst/closures/ClosureEvents.wurst
+++ b/wurst/closures/ClosureEvents.wurst
@@ -266,7 +266,7 @@ function registerEventId(eventid evnt) returns int
 	else if evnt.isPlayerunitEvent()
 		registerPlayerUnitEvent(ConvertPlayerUnitEvent(eventId), function EventListener.generalEventCallback)
 	else if evnt != EVENT_PLAYER_LEAVE and evnt != EVENT_PLAYER_CHAT_FILTER and not evnt.isKeyboardEvent() and not evnt.isMouseEvent()
-		error("registering handleid: " + eventId.toString() + " non-playerunitevent. Except EVENT_PLAYER_LEAVE these are not supported right now.")
+		error("registering handleid: " + eventId + " non-playerunitevent. Except EVENT_PLAYER_LEAVE these are not supported right now.")
 	if evnt.isMouseEvent() and not EventListener.useMouseEvents
 		EventListener.useMouseEvents = true
 		for i = 0 to bj_MAX_PLAYERS - 1
@@ -290,7 +290,7 @@ public function unregisterEventsForUnit(unit u)
 public function unregisterEvents(int id)
 	if id > 0
 		if EventListener.unitListenersFirsts[id] != null
-			Log.trace("unregister unit has listeners. startid: " + id.toString())
+			Log.trace("unregister unit has listeners. startid: " + id)
 			var listener = EventListener.unitListenersFirsts[id]
 			EventListener.unitListenersFirsts[id] = null
 			while listener != null
@@ -321,3 +321,4 @@ init
 			..registerPlayerChatEvent(players[i], "", false)
 
 		registerPlayerUnitEvent(EVENT_PLAYER_UNIT_SPELL_EFFECT, null, () -> EventListener.onSpellEffect(), null)
+

--- a/wurst/closures/ClosureTimersTests.wurst
+++ b/wurst/closures/ClosureTimersTests.wurst
@@ -1,6 +1,5 @@
 package ClosureTimersTests
 import ClosureTimers
-import Wurstunit
 
 var x = 200
 

--- a/wurst/data/ArrayList.wurst
+++ b/wurst/data/ArrayList.wurst
@@ -315,14 +315,14 @@ public class ArrayList<T:>
     /** Returns the element at the specified index (O(1)) */
     function get(int index) returns T
         if index < 0 or index >= size
-            error("ArrayList: Index out of bounds: " + index.toString())
+            error("ArrayList: Index out of bounds: " + index)
 
         return store[startIndex + index]
 
     /** Sets the element at the specified index (O(1)) */
     function set(int index, T elem)
         if index < 0 or index >= size
-            error("ArrayList: Index out of bounds: " + index.toString())
+            error("ArrayList: Index out of bounds: " + index)
         store[startIndex + index] = elem
 
     /** Reads the element at the given index via the [] operator (O(1)).
@@ -351,7 +351,7 @@ public class ArrayList<T:>
         remaining elements left to preserve order (O(n)) */
     function removeAtOrdered(int index) returns T
         if index < 0 or index >= size
-            error("ArrayList: Index out of bounds: " + index.toString())
+            error("ArrayList: Index out of bounds: " + index)
 
         let elem = store[startIndex + index]
 
@@ -373,7 +373,7 @@ public class ArrayList<T:>
     /** Removes the element at the given index by swapping with last element (O(1) - DOES NOT PRESERVE ORDER!) */
     function removeAtUnordered(int index) returns T
         if index < 0 or index >= size
-            error("ArrayList: Index out of bounds: " + index.toString())
+            error("ArrayList: Index out of bounds: " + index)
 
         let elem = store[startIndex + index]
 
@@ -510,7 +510,7 @@ public class ArrayList<T:>
     /** Adds the given element at the given index - WARNING: O(n) operation! */
     function addAt(T elem, int index)
         if index < 0 or index > size
-            error("ArrayList: Index out of bounds: " + index.toString())
+            error("ArrayList: Index out of bounds: " + index)
 
         if size >= capacity
             grow()
@@ -773,3 +773,4 @@ public function ArrayList<string>.joinBy(string separator) returns string
 /** Joins elements from a string list into one string */
 public function ArrayList<string>.join() returns string
     return this.joinBy("")
+

--- a/wurst/data/BitSetTests.wurst
+++ b/wurst/data/BitSetTests.wurst
@@ -1,6 +1,5 @@
 package BitSetTests
 import BitSet
-import Wurstunit
 
 @Test function testGet()
 	let set = bitset(45)

--- a/wurst/data/LinkedList.wurst
+++ b/wurst/data/LinkedList.wurst
@@ -266,7 +266,7 @@ public class LinkedList<T>
 		An index equal to the list's size appends to the end. */
 	function addAt(T elem, int index)
 		if index < 0 or index > size
-			error("LinkedList: Index out of bounds: " + index.toString())
+			error("LinkedList: Index out of bounds: " + index)
 		let entryAtIndex = getEntryUnchecked(index)
 		let entry = new LLEntry<T>(elem, entryAtIndex.prev, entryAtIndex)
 		entryAtIndex.prev.next = entry
@@ -391,7 +391,7 @@ public class LinkedList<T>
 	function toString() returns string
 		if size == 0
 			return "[]"
-		let fold = foldl<string>("[", (i, q) -> q + (i castTo int).toString() + ",")
+		let fold = foldl<string>("[", (i, q) -> q + (i castTo int) + ",")
 		return fold.substring(0, fold.length()-1) + "]"
 
 	/** Removes all elements from the list */
@@ -412,7 +412,7 @@ public class LinkedList<T>
 		into the list, silently returning the wrong element. */
 	private function getEntry(int index) returns LLEntry<T>
 		if index < 0 or index >= size
-			error("LinkedList: Index out of bounds: " + index.toString())
+			error("LinkedList: Index out of bounds: " + index)
 		return getEntryUnchecked(index)
 
 	/** Walks to the entry at the given index without validating it.
@@ -646,3 +646,4 @@ public function LinkedList<string>.join() returns string
 
 init
 	realToIndex(0.)
+

--- a/wurst/data/LinkedListTests.wurst
+++ b/wurst/data/LinkedListTests.wurst
@@ -151,7 +151,7 @@ function testGenerics()
 	list.addAt(7, 4)
 	string elems = ""
 	for elem in list
-		elems += elem.toString()
+		elems += elem
 	elems.assertEquals("1234756")
 
 @Test function testRemoveWhen()
@@ -395,3 +395,4 @@ function testGenerics()
 	let i = list2.backiterator()
 	while bi.hasNext() and i.hasNext()
 		bi.next().assertEquals(i.next())
+

--- a/wurst/data/SparseSet.wurst
+++ b/wurst/data/SparseSet.wurst
@@ -81,7 +81,7 @@ public class SparseSet<T:>
     /** Removes the element at a dense index without preserving order. */
     function removeAt(int index) returns T
         if index < 0 or index >= dense.size()
-            error("SparseSet: Index out of bounds: " + index.toString())
+            error("SparseSet: Index out of bounds: " + index)
 
         let lastIndex = dense.size() - 1
         let removed = dense.get(index)
@@ -153,3 +153,4 @@ public class UnitSparseSetKey implements SparseSetKey<unit>
 
 /** Reusable key provider for SparseSet<unit>. */
 public constant SparseSetKey<unit> UNIT_SPARSE_SET_KEY = new UnitSparseSetKey()
+

--- a/wurst/data/SparseSetBenchmark.wurst
+++ b/wurst/data/SparseSetBenchmark.wurst
@@ -190,8 +190,8 @@ function runCurrentWorkload()
         if phase == 5
             destroyBenchmarkUnits()
         phaseRunning = false
-        print("Finished " + phaseName() + ". Sink delta: " + (sink - phaseStartSink).toString())
-        print("Workload cleaned up. Waiting " + RECOVERY_DELAY.toString() + " seconds for FPS recovery.")
+        print("Finished " + phaseName() + ". Sink delta: " + (sink - phaseStartSink))
+        print("Workload cleaned up. Waiting " + RECOVERY_DELAY + " seconds for FPS recovery.")
         doAfter(RECOVERY_DELAY) ->
             runNextPhase()
 
@@ -199,15 +199,15 @@ function startPhaseWorkload()
     phaseTick = 0
     phaseStartSink = sink
     phaseRunning = true
-    print("Running " + phaseName() + ": " + PHASE_TICKS.toString()
-        + " ticks at " + BENCHMARK_INTERVAL.toString() + " seconds")
+    print("Running " + phaseName() + ": " + PHASE_TICKS
+        + " ticks at " + BENCHMARK_INTERVAL + " seconds")
     doPeriodicallyCounted(BENCHMARK_INTERVAL, PHASE_TICKS) (CallbackCounted _cb) ->
         runCurrentWorkload()
 
 function startPhase()
     if phase == 3
         ensureBenchmarkUnits()
-    print("Starting " + phaseName() + " in " + START_DELAY.toString()
+    print("Starting " + phaseName() + " in " + START_DELAY
         + " seconds; watch the lowest FPS.")
     doAfter(START_DELAY) ->
         startPhaseWorkload()
@@ -217,7 +217,7 @@ function runNextPhase()
     if phase <= PHASE_COUNT
         startPhase()
     else
-        print("SparseSet benchmark complete. Final sink: " + sink.toString())
+        print("SparseSet benchmark complete. Final sink: " + sink)
 
 public function startSparseSetBenchmark()
     if phase != 0
@@ -231,3 +231,4 @@ init
     for i = 0 to bj_MAX_PLAYER_SLOTS - 1
         benchmarkTrigger.registerPlayerChatEvent(players[i], "-sparsebench", true)
     benchmarkTrigger.addAction(function startSparseSetBenchmark)
+

--- a/wurst/dummy/DummyRecycler.wurst
+++ b/wurst/dummy/DummyRecycler.wurst
@@ -13,7 +13,6 @@ import UnitIds
 import Icons
 import ObjectIdGenerator
 import LinkedList
-import TypeCasting
 import ClosureTimers
 
 /** Id of the dummy unit */

--- a/wurst/file/ByteBuffer.wurst
+++ b/wurst/file/ByteBuffer.wurst
@@ -42,7 +42,7 @@ public class ByteBuffer
     You must be sure that the provided integer is in the range [0, 255]. */
 	function writeByteUnsafe(int n)
 		if SAFETY_CHECKS_ENABLED and (n < 0 or n > 255)
-			error("ByteBuffer#writeByteUnsafe ERROR: provided argument (" + n.toString() + ") is not in the range [0, 255].")
+			error("ByteBuffer#writeByteUnsafe ERROR: provided argument (" + n + ") is not in the range [0, 255].")
 		buffer = buffer + n.shiftl(8 * bufferLength)
 		bufferLength++
 		if bufferLength > 3
@@ -52,7 +52,7 @@ public class ByteBuffer
     You must be sure that the provided integer is in the range [0, 65535]. */
 	function writeShortUnsafe(int n)
 		if SAFETY_CHECKS_ENABLED and (n < 0 or n > 65535)
-			error("ByteBuffer#writeShortUnsafe ERROR: provided argument (" + n.toString() + ") is not in the range [0, 65535].")
+			error("ByteBuffer#writeShortUnsafe ERROR: provided argument (" + n + ") is not in the range [0, 65535].")
 		writeByteUnsafe(n.bitAnd(compiletime("11111111".fromBitString())))
 		writeByteUnsafe(n.shiftr(8))
 
@@ -134,3 +134,4 @@ public class ByteBuffer
 			bufferLength = 4
 		intCount = newIntCount
 		bufferLength = min(size - newIntCount * 4, bufferLength)
+

--- a/wurst/file/ByteBufferTests.wurst
+++ b/wurst/file/ByteBufferTests.wurst
@@ -1,6 +1,5 @@
 package ByteBufferTests
 import ByteBuffer
-import Wurstunit
 
 
 @Test

--- a/wurst/file/ChunkedStringTests.wurst
+++ b/wurst/file/ChunkedStringTests.wurst
@@ -1,6 +1,5 @@
 package ChunkedStringTests
 import ChunkedString
-import Wurstunit
 
 
 @Test

--- a/wurst/file/FileIO.wurst
+++ b/wurst/file/FileIO.wurst
@@ -85,11 +85,11 @@ public class File
 			PreloadGenStart()
 
 			if buffer.getChunkCount() >= CHUNKS_PER_FILE
-				error("FileIO(" + filename + ") ERROR: String's chunk count exceeds the limit (" + CHUNKS_PER_FILE.toString() + ").|r")
+				error("FileIO(" + filename + ") ERROR: String's chunk count exceeds the limit (" + CHUNKS_PER_FILE + ").|r")
 
 			for i = 0 to buffer.getChunkCount() - 1
 				let chunk = buffer.getChunk(i)
-				Preload("\" )\ncall BlzSetAbilityTooltip('" + FILE_IO_ABIL_ID_STR + "', \"" + chunk + "\", " + i.toString() + ")\n//")
+				Preload("\" )\ncall BlzSetAbilityTooltip('" + FILE_IO_ABIL_ID_STR + "', \"" + chunk + "\", " + i + ")\n//")
 
 			Preload("\" )\nendfunction\nfunction a takes nothing returns nothing\n //")
 			PreloadGenEnd(this.filename)
@@ -131,3 +131,4 @@ init
 
 	for i = 1 to CHUNKS_PER_FILE
 		dummy.setTooltipNormal(i, " ")
+

--- a/wurst/file/MultibyteDiagnostics.wurst
+++ b/wurst/file/MultibyteDiagnostics.wurst
@@ -41,15 +41,15 @@ init
 public function runMultibyteDiagnostics()
 	checksRun = 0
 	checksFailed = 0
-	print("ENABLE_MULTIBYTE_SUPPORT = " + ENABLE_MULTIBYTE_SUPPORT.toString())
-	print("PARTIAL_CHAR_HASH = " + PARTIAL_CHAR_HASH.toString() + " (legacy = 1843378377)")
-	print("LEAD4_HASH = " + LEAD4_HASH.toString())
+	print("ENABLE_MULTIBYTE_SUPPORT = " + ENABLE_MULTIBYTE_SUPPORT)
+	print("PARTIAL_CHAR_HASH = " + PARTIAL_CHAR_HASH + " (legacy = 1843378377)")
+	print("LEAD4_HASH = " + LEAD4_HASH)
 
 	// Which normalized form the game hashes invalid slices as - all invalid slices
 	// share one hash, so they are collapsed to a single replacement form first.
-	print("hash of empty string: " + "".getHash().toString())
-	print("hash of replacement char: " + "�".getHash().toString())
-	print("hash of question mark: " + "?".getHash().toString())
+	print("hash of empty string: " + "".getHash())
+	print("hash of replacement char: " + "�".getHash())
+	print("hash of question mark: " + "?".getHash())
 
 	// Raw engine semantics: 2-byte (cyrillic/umlauts), 3-byte (CJK), 4-byte (emoji)
 	let two = "дä"
@@ -63,8 +63,8 @@ public function runMultibyteDiagnostics()
 	check("full char slice is valid", two.substring(0, 2) == "д")
 	check("slices are lossless", two.substring(0, 1) + two.substring(1, 4) == two)
 	// 4-byte lead slices are expected to keep their own hash instead of the marker
-	print("4-byte slice hashes: " + four.substring(0, 1).getHash().toString() + ", "
-		+ four.substring(0, 2).getHash().toString() + ", " + four.substring(0, 3).getHash().toString())
+	print("4-byte slice hashes: " + four.substring(0, 1).getHash() + ", "
+		+ four.substring(0, 2).getHash() + ", " + four.substring(0, 3).getHash())
 	check("4-byte lead slice matches LEAD4_HASH", four.substring(0, 1).getHash() == LEAD4_HASH)
 
 	// Boundary classification
@@ -82,19 +82,20 @@ public function runMultibyteDiagnostics()
 		iterated += c
 		count++
 	check("iteration reassembles string", iterated == "aд中😀b")
-	check("iteration counts 5 chars, got " + count.toString(), count == 5)
+	check("iteration counts 5 chars, got " + count, count == 5)
 
 	// ChunkedString round trips with cuts landing inside multibyte chars
 	let input = "абвгдеёжз中文漢字😀🙂ab"
 	for chunkSize = 3 to 8
 		let cstring = new ChunkedString(chunkSize)
 		cstring.append(input)
-		check("ChunkedString round trip, chunkSize " + chunkSize.toString(), cstring.getUnsafeString() == input)
+		check("ChunkedString round trip, chunkSize " + chunkSize, cstring.getUnsafeString() == input)
 		destroy cstring
 
 	let mode = isLua ? "lua" : "jass"
 	if checksFailed == 0
-		print("|cff00ff00All " + checksRun.toString() + " checks passed|r (" + mode + " mode)")
+		print("|cff00ff00All " + checksRun + " checks passed|r (" + mode + " mode)")
 	else
-		print("|cffff0000" + checksFailed.toString() + " of " + checksRun.toString()
+		print("|cffff0000" + checksFailed + " of " + checksRun
 			+ " checks FAILED|r (" + mode + " mode)")
+

--- a/wurst/file/SaveLoadData.wurst
+++ b/wurst/file/SaveLoadData.wurst
@@ -57,7 +57,7 @@ public function player.saveData(string slotName, string data)
 /** Blockingly saves the given data string for the given player. */
 public function player.saveData(string slotName, ChunkedString data)
 	if not this.isIngame()
-		error("Attempting to save data for player who isn't ingame! id: " + this.getId().toString())
+		error("Attempting to save data for player who isn't ingame! id: " + this.getId())
 
 	new File(slotName.endsWith(".pld") ? slotName : slotName + ".pld")
 		..write(this, data)..close()
@@ -90,3 +90,4 @@ public function player.loadData(string slotName, LoadListener listener)
 
 function shouldReadFile() returns boolean
 	return READ_FILES_IN_REPLAYS or gameStatus != REPLAY
+

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -70,7 +70,7 @@ public abstract class Serializable
         if name.length() > MAX_NAME_LENGTH
             error("name " + name + " too long.")
 
-        let prop = name + "=" + value.toString()
+        let prop = name + "=" + value
         var propLen = prop.length().toString()
         while propLen.length() < LEN_LENGTH
             propLen = "0" + propLen
@@ -82,7 +82,7 @@ public abstract class Serializable
         if name.length() > MAX_NAME_LENGTH
             error("name " + name + " too long.")
 
-        let prop = name + "=" + value.toString()
+        let prop = name + "=" + value
         var propLen = prop.length().toString()
         while propLen.length() < LEN_LENGTH
             propLen = "0" + propLen
@@ -179,3 +179,4 @@ public abstract class Serializable
     abstract function serializeProperties()
 
     abstract function deserializeProperties()
+

--- a/wurst/math/AngleTests.wurst
+++ b/wurst/math/AngleTests.wurst
@@ -1,6 +1,4 @@
 package AngleTests
-import Angle
-import Wurstunit
 
 
 @Test function testAngle()

--- a/wurst/math/Bitwise.wurst
+++ b/wurst/math/Bitwise.wurst
@@ -120,7 +120,7 @@ public function int.toBitString() returns string
 	var value = this
 
 	while value != 0
-		result = (value mod 2).toString() + result
+		result = (value mod 2) + result
 		value = bwShiftr32(value, 1)
 
 	return result
@@ -292,3 +292,4 @@ public function int.shiftl(int amount) returns int
 **/
 public function int.shiftr(int amount) returns int
 	return bwShiftr32(this, amount)
+

--- a/wurst/math/InterpolationTests.wurst
+++ b/wurst/math/InterpolationTests.wurst
@@ -1,6 +1,5 @@
 package InterpolationTests
 import Interpolation
-import Wurstunit
 
 
 @Test

--- a/wurst/math/LineGeometryTests.wurst
+++ b/wurst/math/LineGeometryTests.wurst
@@ -1,6 +1,5 @@
 package LineGeometryTests
 import LineGeometry
-import Wurstunit
 
 @Test function testLineFormular()
 	let p1 = vec2(0, 2)

--- a/wurst/math/MathsTests.wurst
+++ b/wurst/math/MathsTests.wurst
@@ -1,6 +1,4 @@
 package MathsTests
-import Maths
-import Wurstunit
 
 @Test function minmax()
 	let three = 3

--- a/wurst/math/PolygonTests.wurst
+++ b/wurst/math/PolygonTests.wurst
@@ -195,8 +195,8 @@ function benchmarkPoint(int index) returns vec2
 			mixedQueries++
 		totalCandidates += candidates
 	totalCandidates.assertLessThan(linearEdges)
-	print("Polygon 10000-lookups: mixed=" + mixedQueries.toString() +
-		", linearEdges=" + linearEdges.toString() + ", candidateEdges=" + totalCandidates.toString())
+	print("Polygon 10000-lookups: mixed=" + mixedQueries +
+		", linearEdges=" + linearEdges + ", candidateEdges=" + totalCandidates)
 	destroy polygon
 
 @Test function oversizedGridFallsBackToExactLinearClassification()
@@ -297,3 +297,4 @@ public function verifyLuaGuardPathsReturnSafelyIngame()
 	borders.size().assertEquals(0)
 	destroy borders
 	destroy unsealedPolygon
+

--- a/wurst/math/RaycastTests.wurst
+++ b/wurst/math/RaycastTests.wurst
@@ -1,6 +1,5 @@
 package RaycastTests
 import Raycast
-import Wurstunit
 
 constant EPSILON = 0.0001
 

--- a/wurst/math/Vectors.wurst
+++ b/wurst/math/Vectors.wurst
@@ -120,7 +120,7 @@ public function vec2.inRange(vec2 v2, real radius) returns boolean
 
 /** Get a String-representation of this Vector (for debugging) */
 public function vec2.toString() returns string
-	return "Vector2 [" + this.x.toString() + ", " + this.y.toString() + "]"
+	return "Vector2 [" + this.x + ", " + this.y + "]"
 
 /** Get this vetor's angle to another one */
 public function vec2.angleTo(vec2 v) returns angle
@@ -365,7 +365,7 @@ public function vec3.distanceToSq(vec3 v) returns real
 
 /** Get a String-represantation of the vector (for debugging) */
 public function vec3.toString() returns string
-	return "Vector3 [ " + this.x.toString() + ", " + this.y.toString() + ", " + this.z.toString() + " ]"
+	return "Vector3 [ " + this.x + ", " + this.y + ", " + this.z + " ]"
 
 /** Rotate this vector around an axis */
 public function vec3.rotate(vec3 axis, angle ang) returns vec3
@@ -468,4 +468,5 @@ public function vec3.isInPolygon2d(vararg vec3 args) returns bool
 					test--
 		result = test != 0
 	return result
+
 

--- a/wurst/math/VectorsTests.wurst
+++ b/wurst/math/VectorsTests.wurst
@@ -1,6 +1,5 @@
 package VectorsTests
-import Vectors
-import Wurstunit
+import Polygon
 
 
 @Test
@@ -55,10 +54,14 @@ function vectorTests()
 	let test2 = vec2(-4, -6)
 	let test3 = vec2(-2, 2)
 	let points = [vec2(-3, -6), vec2(4, 5), vec2(-4, 5), vec2(3, -2)]
-	test1.isInPolygon(points[0], points[1], points[2], points[3]).assertTrue()
-	test2.isInPolygon(points[0], points[1], points[2], points[3]).assertFalse()
-	test3.isInPolygon(points[0], points[1], points[2]).assertTrue()
-	test1.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertTrue()
-	test2.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertFalse()
-	test3.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3()).assertTrue()
+	let polygon = new Polygon(points[0], points[1], points[2], points[3])
+	polygon.contains(test1).assertTrue()
+	polygon.contains(test2).assertFalse()
+	polygon.contains(test1.toVec3().toVec2()).assertTrue()
+	polygon.contains(test2.toVec3().toVec2()).assertFalse()
+	destroy polygon
+	let triangle = new Polygon(points[0], points[1], points[2])
+	triangle.contains(test3).assertTrue()
+	triangle.contains(test3.toVec3().toVec2()).assertTrue()
+	destroy triangle
 

--- a/wurst/objediting/ObjectIds.wurst
+++ b/wurst/objediting/ObjectIds.wurst
@@ -1,9 +1,8 @@
 package ObjectIds
 import NoWurst
 import ErrorHandling
-import AbilityIds
 import LinkedList
-import TypeCasting
+import public TypeCasting
 import ObjEditingCommons
 
 constant CHARMAP = ".................................!.#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[.]^_`abcdefghijklmnopqrstuvwxyz{|}~................................................................................................................................."

--- a/wurst/objediting/ObjectIdsTests.wurst
+++ b/wurst/objediting/ObjectIdsTests.wurst
@@ -2,7 +2,6 @@ package ObjectIdsTests
 import ObjectIds
 import ObjEditingCommons
 import AbilityIds
-import Wurstunit
 
 @Test function asListIntTest()
 	commaList(

--- a/wurst/objediting/UpgradeObjEditing.wurst
+++ b/wurst/objediting/UpgradeObjEditing.wurst
@@ -270,17 +270,17 @@ public class W3QDefinition
 		def.setLevelsDataString("gub1", levels, 0, lc)
 
 	function setEffectType(int effectIndex, UpgradeEffectType effectType)
-		def.setLvlDataString(EFFECT_TAG_PREFIX + effectIndex.toString(), 0, 0,
+		def.setLvlDataString(EFFECT_TAG_PREFIX + effectIndex, 0, 0,
 			effectType.toIdentifierString())
 
 	function setEffectBase(int effectIndex, real value)
-		def.setLvlDataUnreal(BASE_TAG_PREFIX + effectIndex.toString(), 0, 0, value)
+		def.setLvlDataUnreal(BASE_TAG_PREFIX + effectIndex, 0, 0, value)
 
 	function setEffectIncrement(int effectIndex, real value)
-		def.setLvlDataUnreal(INCREMENT_TAG_PREFIX + effectIndex.toString(), 0, 0, value)
+		def.setLvlDataUnreal(INCREMENT_TAG_PREFIX + effectIndex, 0, 0, value)
 
 	function setEffectCode(int effectIndex, string value)
-		def.setLvlDataString(CODE_TAG_PREFIX + effectIndex.toString(), 0, 0, value)
+		def.setLvlDataString(CODE_TAG_PREFIX + effectIndex, 0, 0, value)
 
 	function setEffect(int effectIndex, UpgradeEffectType effectType, real base)
 		setEffectType(effectIndex, effectType)
@@ -526,4 +526,5 @@ public class UpgradeDefinition extends W3QDefinition
 		super.setEffectType(effectIndex, UpgradeEffectType.UnitAvailabilityChange)
 		super.setEffectCode(effectIndex, unitId)
 		super.setEffectBase(effectIndex, available ? -1 : 1)
+
 

--- a/wurst/util/Colors.wurst
+++ b/wurst/util/Colors.wurst
@@ -200,15 +200,15 @@ public function color.toColorString() returns string
 
 /** Returns the tuple in string format color(r,g,b) */
 public function color.toString() returns string
-	return "color(" + (this.red).toString() + ", " + (this.green).toString() + ", " + (this.blue).toString() + ")"
+	return "color(" + (this.red) + ", " + (this.green) + ", " + (this.blue) + ")"
 
 /** Returns the tuple in string format colorA(r,g,b,a) */
 public function colorA.toString() returns string
-	return "colorA(" + (this.red).toString() + ", " + (this.green).toString() + ", " + (this.blue).toString() + ", " + (this.alpha).toString() + ")"
+	return "colorA(" + (this.red) + ", " + (this.green) + ", " + (this.blue) + ", " + (this.alpha) + ")"
 
 /** Returns the tuple in string format colorHSV(h,s,v) */
 public function colorHSV.toString() returns string
-	return "colorHSV(" + (this.h).toString() + ", " + (this.s).toString() + ", " + (this.v).toString() + ")"
+	return "colorHSV(" + (this.h) + ", " + (this.s) + ", " + (this.v) + ")"
 
 /** Converts and int to a hexnumber */
 public function toHex(int number) returns string
@@ -274,5 +274,6 @@ public function string.color(colorA which) returns string
 
 init
 	initializeTable()
+
 
 

--- a/wurst/util/ColorsTests.wurst
+++ b/wurst/util/ColorsTests.wurst
@@ -1,6 +1,4 @@
 package ColorsTests
-import Colors
-import Wurstunit
 
 function colorHSV.assert()
 	let delta = 0.01

--- a/wurst/util/GameTimerTests.wurst
+++ b/wurst/util/GameTimerTests.wurst
@@ -1,6 +1,5 @@
 package GameTimerTests
 import GameTimer
-import Wurstunit
 
 @Test function testGameTimer()
 	assertTrue(getElapsedGameTime() > 0)

--- a/wurst/util/GroupUtils.wurst
+++ b/wurst/util/GroupUtils.wurst
@@ -101,11 +101,11 @@ function createGroups(int number)
 				push(CreateGroup())
 
 	if numTotal >= GROUP_NUMBER_LIMIT and not shownMaxError
-		Log.warn("Maximum number of GroupUtils groups (" + GROUP_NUMBER_LIMIT.toString() + ") created. "
+		Log.warn("Maximum number of GroupUtils groups (" + GROUP_NUMBER_LIMIT + ") created. "
 			+ "All newly created groups will be non-recyclable.")
 		shownMaxError = true
 
-@compiletime function initialize()
+function initialize()
 	createGroups(START_CREATE_GROUPS)
 
 init

--- a/wurst/util/MapBounds.wurst
+++ b/wurst/util/MapBounds.wurst
@@ -1,10 +1,9 @@
 package MapBounds
 import NoWurst
+import Annotations
 import Vectors
 import Region
 import Rect
-import MagicFunctions
-import Annotations
 
 public rect playableMapRect
 public region playableMapRegion
@@ -42,11 +41,20 @@ public function vec3.inBounds() returns boolean
 public function randomPointOnMap() returns vec2
 	return vec2(GetRandomReal(playableMin.x, playableMax.x), GetRandomReal(playableMin.y, playableMax.y))
 
-/** Must be at init because globals get initialized before map bounds */
-@compiletime function initMapBounds()
-	playableMapRect   = compiletime ? Rect(-1024, -1024, 1024, 1024) : GetPlayableMapRect()
+/** Values used while compiling tests and compiletime code. */
+@compiletime function initMapBoundsValues()
+	playableMin = vec2(-1024, -1024)
+	playableMax = vec2(1024, 1024)
+	boundMin = vec2(-1536, -1536)
+	boundMax = vec2(1536, 1536)
+	playableCenter = (playableMin + playableMax) * .5
+	boundCenter = (boundMin + boundMax) * .5
+
+/** Must be at init because globals get initialized before map bounds. */
+function initMapBounds()
+	playableMapRect   = GetPlayableMapRect()
 	playableMapRegion = CreateRegion()..addRect(playableMapRect)
-	boundRect = compiletime ? Rect(-1536, -1536, 1536, 1536) : GetWorldBounds()
+	boundRect = GetWorldBounds()
 	boundRegion	= CreateRegion()..addRect(boundRect)
 	playableMin	= vec2(playableMapRect.getMinX(), playableMapRect.getMinY())
 	playableMax	= vec2(playableMapRect.getMaxX(), playableMapRect.getMaxY())

--- a/wurst/util/MapBounds.wurst
+++ b/wurst/util/MapBounds.wurst
@@ -1,9 +1,10 @@
 package MapBounds
 import NoWurst
-import Annotations
 import Vectors
 import Region
 import Rect
+import MagicFunctions
+import Annotations
 
 public rect playableMapRect
 public region playableMapRegion
@@ -41,20 +42,11 @@ public function vec3.inBounds() returns boolean
 public function randomPointOnMap() returns vec2
 	return vec2(GetRandomReal(playableMin.x, playableMax.x), GetRandomReal(playableMin.y, playableMax.y))
 
-/** Values used while compiling tests and compiletime code. */
-@compiletime function initMapBoundsValues()
-	playableMin = vec2(-1024, -1024)
-	playableMax = vec2(1024, 1024)
-	boundMin = vec2(-1536, -1536)
-	boundMax = vec2(1536, 1536)
-	playableCenter = (playableMin + playableMax) * .5
-	boundCenter = (boundMin + boundMax) * .5
-
 /** Must be at init because globals get initialized before map bounds. */
-function initMapBounds()
-	playableMapRect   = GetPlayableMapRect()
+@compiletime function initMapBounds()
+	playableMapRect   = compiletime ? Rect(-1024, -1024, 1024, 1024) : GetPlayableMapRect()
 	playableMapRegion = CreateRegion()..addRect(playableMapRect)
-	boundRect = GetWorldBounds()
+	boundRect = compiletime ? Rect(-1536, -1536, 1536, 1536) : GetWorldBounds()
 	boundRegion	= CreateRegion()..addRect(boundRect)
 	playableMin	= vec2(playableMapRect.getMinX(), playableMapRect.getMinY())
 	playableMax	= vec2(playableMapRect.getMaxX(), playableMapRect.getMaxY())

--- a/wurst/util/MapBoundsTests.wurst
+++ b/wurst/util/MapBoundsTests.wurst
@@ -1,10 +1,9 @@
 package MapBoundsTests
 import MapBounds
-import Wurstunit
 
 @Test function testMapBounds()
-	playableMapRect.getMinX().assertEquals(-1024)
-	playableMapRect.getMaxX().assertEquals(1024)
-	playableMapRect.getMinY().assertEquals(-1024)
-	playableMapRect.getMaxY().assertEquals(1024)
+	playableMin.x.assertEquals(-1024)
+	playableMax.x.assertEquals(1024)
+	playableMin.y.assertEquals(-1024)
+	playableMax.y.assertEquals(1024)
 	(playableMin + playableMax).toString().assertEquals(playableCenter.toString())

--- a/wurst/util/MapBoundsTests.wurst
+++ b/wurst/util/MapBoundsTests.wurst
@@ -2,8 +2,8 @@ package MapBoundsTests
 import MapBounds
 
 @Test function testMapBounds()
-	playableMin.x.assertEquals(-1024)
-	playableMax.x.assertEquals(1024)
-	playableMin.y.assertEquals(-1024)
-	playableMax.y.assertEquals(1024)
+	playableMapRect.getMinX().assertEquals(-1024)
+	playableMapRect.getMaxX().assertEquals(1024)
+	playableMapRect.getMinY().assertEquals(-1024)
+	playableMapRect.getMaxY().assertEquals(1024)
 	(playableMin + playableMax).toString().assertEquals(playableCenter.toString())

--- a/wurst/util/StandardTextTags.wurst
+++ b/wurst/util/StandardTextTags.wurst
@@ -30,7 +30,7 @@ public function standardTextTag(vec2 pos, string text) returns texttag
 /** Create a texttag that matches the style of the standard warcraft 3 Critical
 	Strike ability. */
 public function createCriticalStrikeTextTag(unit u, int damage) returns texttag
-	let text = damage.toString() + "!"
+	let text = damage + "!"
 	return standardTextTag(u.getPos(), text)
 		..setColor(255, 0, 0, 255)
 		..setVelocity(0., .04)
@@ -40,7 +40,7 @@ public function createCriticalStrikeTextTag(unit u, int damage) returns texttag
 /** Create a texttag that matches the style of the standard warcraft 3 gold
 	bounty. */
 public function createGoldBountyTextTag(unit u, int bounty, player killer) returns texttag
-	let text = "+" + bounty.toString()
+	let text = "+" + bounty
 	let pos  = u.getPos() - OFFSET
 	return standardTextTag(pos, text)
 		..setColor(255, 220, 0, 255)
@@ -49,7 +49,7 @@ public function createGoldBountyTextTag(unit u, int bounty, player killer) retur
 /** Create a texttag that matches the style of the standard warcraft 3 gold
 	bounty. */
 public function createGoldBountyTextTag(unit u, int bounty) returns texttag
-	let text = "+" + bounty.toString()
+	let text = "+" + bounty
 	let pos  = u.getPos() - OFFSET
 	return standardTextTag(pos, text)..setColor(255, 220, 0, 255)
 
@@ -57,7 +57,7 @@ public function createGoldBountyTextTag(unit u, int bounty) returns texttag
 /** Create a texttag that matches the style of the standard warcraft 3 lumber
 	bounty. */
 public function createLumberBountyTextTag(unit u, int bounty, player killer) returns texttag
-	let text = "+" + bounty.toString()
+	let text = "+" + bounty
 	let pos  = u.getPos() - OFFSET
 	return standardTextTag(pos, text)
 		..setColor(0, 200, 80, 255)
@@ -66,7 +66,7 @@ public function createLumberBountyTextTag(unit u, int bounty, player killer) ret
 /** Create a texttag that matches the style of the standard warcraft 3 lumber
 	bounty. */
 public function createLumberBountyTextTag(unit u, int bounty) returns texttag
-	let text = "+" + bounty.toString()
+	let text = "+" + bounty
 	let pos  = u.getPos() - OFFSET
 	return standardTextTag(pos, text)..setColor(0, 200, 80, 255)
 
@@ -74,7 +74,7 @@ public function createLumberBountyTextTag(unit u, int bounty) returns texttag
 /** Create a texttag that matches the style of the standard warcraft 3 Mana Burn
 	ability. */
 public function createManaBurnTextTag(unit u, int damage) returns texttag
-	let text = "-" + damage.toString()
+	let text = "-" + damage
 	let pos  = u.getPos() - OFFSET
 	return standardTextTag(pos, text)
 		..setColor(82, 82, 255, 255)
@@ -101,3 +101,4 @@ public function createShadowStrikeTextTag(unit u, int damage, bool isInitialDama
 		..setColor(160, 255, 0, 255)
 		..setVelocity(0., .04)
 		..setLifespan(5.)
+

--- a/wurst/util/StringUtils.wurst
+++ b/wurst/util/StringUtils.wurst
@@ -178,7 +178,7 @@ public function string.isValidDescription() returns bool
 	var isValid = true
 	if this.length() > WC3LIMIT_OBJECTS_DESCRIPTION_LENGTH
 		isValid = false
-		error("String <"+this+"> is too long. Length: "+this.length().toString())
+		error("String <"+this+"> is too long. Length: "+this.length())
 	return isValid
 
 /** Replaces all occurences of any character from given charlist by a given replacement string.*/
@@ -464,3 +464,4 @@ function c2sInit()
 	c2s['}'] = "}"
 	c2s['~'] = "~"
 	c2s[127] = ""
+

--- a/wurst/util/TerrainUtilsTests.wurst
+++ b/wurst/util/TerrainUtilsTests.wurst
@@ -1,7 +1,6 @@
 package TerrainUtilsTests
 import TerrainUtils
 import MapBounds
-import Wurstunit
 
 @Test function testMapCorners()
 	boundMin.getTile().id.assertEquals(0)

--- a/wurst/util/Time.wurst
+++ b/wurst/util/Time.wurst
@@ -212,19 +212,19 @@ function duration.displayMagnitude(string hrs, string mins, string secs, string 
 
 	var result = ""
 	if hours > 0
-		result += hours.toString()
+		result += hours
 		result += hrs
 
 	if minutes > 0 or result.length() > 0
-		result += minutes.toString()
+		result += minutes
 		result += mins
 
 	if seconds > 0 or result.length() > 0
-		result += seconds.toString()
+		result += seconds
 		result += secs
 
 	if result.length() == 0 and total > 0.
-		return (total * 1000.0).toInt().toString() + ms
+		return (total * 1000.0).toInt() + ms
 
 	if result.length() == 0
 		return "0"
@@ -287,3 +287,4 @@ public function durationToIndex(duration dur) returns int
 
 public function durationFromIndex(int index) returns duration
 	return duration(realFromIndex(index))
+

--- a/wurst/util/TimeTests.wurst
+++ b/wurst/util/TimeTests.wurst
@@ -1,6 +1,5 @@
 package TimeTests
 import Time
-import Wurstunit
 
 
 @Test function testDisplay()


### PR DESCRIPTION
Clean up all warnings reported by typecheck.

This removes redundant imports and conversions, replaces deprecated polygon test usage, and keeps compiletime tests working without compiletime native-handle initialization.

Checks:
- grill typecheck
- grill test --quiet