### PR TITLE
test: eliminate stdlib source warnings

### DIFF
--- a/wurst/_handles/DestructableTests.wurst
+++ b/wurst/_handles/DestructableTests.wurst
@@ -1,6 +1,4 @@
 package DestructableTests
-import Destructable
-import Wurstunit
 
 @Test function testDestructables()
 	let destr = createDestructable(0, ZERO2, 0 .fromDeg(), 1, -1)

--- a/wurst/_handles/DialogTests.wurst
+++ b/wurst/_handles/DialogTests.wurst
@@ -1,6 +1,5 @@
 package DialogTests
 import Dialog
-import Wurstunit
 
 @Test function testDialog()
 	let dia = createDialog()

--- a/wurst/_handles/EffectTests.wurst
+++ b/wurst/_handles/EffectTests.wurst
@@ -1,6 +1,4 @@
 package EffectTests
-import Effect
-import Wurstunit
 
 @Test function testEffect()
 	let eff = addEffect("testPath", vec2(12,32))

--- a/wurst/_handles/PlayerTests.wurst
+++ b/wurst/_handles/PlayerTests.wurst
@@ -1,6 +1,4 @@
 package PlayerTests
-import Player
-import Wurstunit
 
 @Test function testPlayer()
 	let p = Player(0)

--- a/wurst/_handles/PlayercolorTests.wurst
+++ b/wurst/_handles/PlayercolorTests.wurst
@@ -1,6 +1,4 @@
 package PlayercolorTests
-import Playercolor
-import Wurstunit
 
 @Test public function testToInt()
 	PLAYER_COLOR_RED.toInt().assertEquals(0)

--- a/wurst/_handles/RectTests.wurst
+++ b/wurst/_handles/RectTests.wurst
@@ -1,6 +1,4 @@
 package RectTests
-import Rect
-import Wurstunit
 
 
 @Test
@@ -25,4 +23,3 @@ function rectTest()
 
 	rekt.getCenterX().assertEquals(2)
 	rekt.getCenterY().assertEquals(2)
-

--- a/wurst/closures/ClosureTimersTests.wurst
+++ b/wurst/closures/ClosureTimersTests.wurst
@@ -1,6 +1,5 @@
 package ClosureTimersTests
 import ClosureTimers
-import Wurstunit
 
 var x = 200
 

--- a/wurst/data/BitSetTests.wurst
+++ b/wurst/data/BitSetTests.wurst
@@ -1,6 +1,5 @@
 package BitSetTests
 import BitSet
-import Wurstunit
 
 @Test function testGet()
 	let set = bitset(45)

--- a/wurst/file/ByteBufferTests.wurst
+++ b/wurst/file/ByteBufferTests.wurst
@@ -1,6 +1,5 @@
 package ByteBufferTests
 import ByteBuffer
-import Wurstunit
 
 
 @Test
@@ -110,4 +109,3 @@ function byteBufferEndiannessTest()
 	byteBuffer.readByte().assertEquals(0x02)
 	byteBuffer.readByte().assertEquals(0x01)
 	destroy byteBuffer
-

--- a/wurst/file/ChunkedStringTests.wurst
+++ b/wurst/file/ChunkedStringTests.wurst
@@ -1,6 +1,5 @@
 package ChunkedStringTests
 import ChunkedString
-import Wurstunit
 
 
 @Test
@@ -41,4 +40,3 @@ function chunkedStringIteration()
 		result += cstring.readChunk()
 
 	result.assertEquals("abcdef")
-

--- a/wurst/math/AngleTests.wurst
+++ b/wurst/math/AngleTests.wurst
@@ -1,6 +1,4 @@
 package AngleTests
-import Angle
-import Wurstunit
 
 
 @Test function testAngle()
@@ -17,4 +15,3 @@ import Wurstunit
 	halfTurn.fromRad().degrees().assertEquals(180., 0.001)
 	let three = 3
 	three.fromRad().radians().assertEquals(3., 0.0001)
-

--- a/wurst/math/InterpolationTests.wurst
+++ b/wurst/math/InterpolationTests.wurst
@@ -1,6 +1,5 @@
 package InterpolationTests
 import Interpolation
-import Wurstunit
 
 
 @Test
@@ -120,4 +119,3 @@ function linearVecTest()
 
 	let atStop = (hermite(start, stop, t1, t2, 1.) - hermite(start, stop, t1, t2, 1. - h)) / h
 	atStop.assertEquals(t2, 0.05)
-

--- a/wurst/math/LineGeometryTests.wurst
+++ b/wurst/math/LineGeometryTests.wurst
@@ -1,6 +1,5 @@
 package LineGeometryTests
 import LineGeometry
-import Wurstunit
 
 @Test function testLineFormular()
 	let p1 = vec2(0, 2)

--- a/wurst/math/MathsTests.wurst
+++ b/wurst/math/MathsTests.wurst
@@ -1,6 +1,4 @@
 package MathsTests
-import Maths
-import Wurstunit
 
 @Test function minmax()
 	let three = 3

--- a/wurst/math/RaycastTests.wurst
+++ b/wurst/math/RaycastTests.wurst
@@ -1,6 +1,5 @@
 package RaycastTests
 import Raycast
-import Wurstunit
 
 constant EPSILON = 0.0001
 

--- a/wurst/math/VectorsTests.wurst
+++ b/wurst/math/VectorsTests.wurst
@@ -1,6 +1,5 @@
 package VectorsTests
-import Vectors
-import Wurstunit
+import Polygon
 
 
 @Test
@@ -55,10 +54,13 @@ function vectorTests()
 	let test2 = vec2(-4, -6)
 	let test3 = vec2(-2, 2)
 	let points = [vec2(-3, -6), vec2(4, 5), vec2(-4, 5), vec2(3, -2)]
-	test1.isInPolygon(points[0], points[1], points[2], points[3]).assertTrue()
-	test2.isInPolygon(points[0], points[1], points[2], points[3]).assertFalse()
-	test3.isInPolygon(points[0], points[1], points[2]).assertTrue()
-	test1.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertTrue()
-	test2.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3(), points[3].toVec3()).assertFalse()
-	test3.toVec3().isInPolygon2d(points[0].toVec3(), points[1].toVec3(), points[2].toVec3()).assertTrue()
-
+	let polygon = new Polygon(points[0], points[1], points[2], points[3])
+	let triangle = new Polygon(points[0], points[1], points[2])
+	polygon.contains(test1).assertTrue()
+	polygon.contains(test2).assertFalse()
+	triangle.contains(test3).assertTrue()
+	polygon.contains(test1.toVec3().toVec2()).assertTrue()
+	polygon.contains(test2.toVec3().toVec2()).assertFalse()
+	triangle.contains(test3.toVec3().toVec2()).assertTrue()
+	destroy polygon
+	destroy triangle

--- a/wurst/objediting/ObjectIds.wurst
+++ b/wurst/objediting/ObjectIds.wurst
@@ -1,12 +1,16 @@
 package ObjectIds
 import NoWurst
 import ErrorHandling
-import AbilityIds
 import LinkedList
+// Provides stringToIndex/stringFromIndex for legacy string generic bindings.
 import TypeCasting
 import ObjEditingCommons
 
 constant CHARMAP = ".................................!.#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[.]^_`abcdefghijklmnopqrstuvwxyz{|}~................................................................................................................................."
+
+init
+	// LinkedList<string> resolves its generic conversions through TypeCasting.
+	stringToIndex("")
 
 /** Convert a integer id value into a 4-letter id code. */
 public function toRawCode(int value) returns string
@@ -74,4 +78,3 @@ public function commaList(vararg UnitTargetType tags) returns string
 	for t in tags
 		list.add(t.toObjectString())
 	return commaList(list)
-

--- a/wurst/objediting/ObjectIdsTests.wurst
+++ b/wurst/objediting/ObjectIdsTests.wurst
@@ -2,7 +2,6 @@ package ObjectIdsTests
 import ObjectIds
 import ObjEditingCommons
 import AbilityIds
-import Wurstunit
 
 @Test function asListIntTest()
 	commaList(

--- a/wurst/util/ColorsTests.wurst
+++ b/wurst/util/ColorsTests.wurst
@@ -1,6 +1,4 @@
 package ColorsTests
-import Colors
-import Wurstunit
 
 function colorHSV.assert()
 	let delta = 0.01

--- a/wurst/util/GameTimerTests.wurst
+++ b/wurst/util/GameTimerTests.wurst
@@ -1,6 +1,5 @@
 package GameTimerTests
 import GameTimer
-import Wurstunit
 
 @Test function testGameTimer()
 	assertTrue(getElapsedGameTime() > 0)

--- a/wurst/util/MapBoundsTests.wurst
+++ b/wurst/util/MapBoundsTests.wurst
@@ -1,6 +1,5 @@
 package MapBoundsTests
 import MapBounds
-import Wurstunit
 
 @Test function testMapBounds()
 	playableMapRect.getMinX().assertEquals(-1024)

--- a/wurst/util/TerrainUtilsTests.wurst
+++ b/wurst/util/TerrainUtilsTests.wurst
@@ -1,7 +1,6 @@
 package TerrainUtilsTests
 import TerrainUtils
 import MapBounds
-import Wurstunit
 
 @Test function testMapCorners()
 	boundMin.getTile().id.assertEquals(0)

--- a/wurst/util/TimeTests.wurst
+++ b/wurst/util/TimeTests.wurst
@@ -1,6 +1,5 @@
 package TimeTests
 import Time
-import Wurstunit
 
 
 @Test function testDisplay()
@@ -40,4 +39,3 @@ import Wurstunit
 	(-1.).hours().display().assertEquals("-PT1H0M0S")
 	(0.).seconds().displayVerbose().assertEquals("0")
 	(61.).seconds().displayVerbose().assertEquals("1 minutes, and 1 seconds")
-


### PR DESCRIPTION
Follow-up to #454 and #456.\n\nRemoves compiler warnings introduced when tests were moved into dedicated packages:\n- drops redundant/unused imports;\n- keeps the deprecated polygon compatibility APIs, while exercising the recommended Polygon API in the restored test;\n- preserves the TypeCasting import required by LinkedList<string> and marks its generic conversion dependency explicitly.\n\nVerification:\n- nix develop /home/daniel/Repositories/tever/tever_main -c bash -lc 'grill test VectorsTests' — 5/5, compilation warnings: 0\n- nix develop /home/daniel/Repositories/tever/tever_main -c bash -lc 'grill test ObjectIdsTests' — 5/5, compilation warnings: 0\n- nix develop /home/daniel/Repositories/tever/tever_main -c bash -lc 'grill typecheck --quiet && grill test --quiet' — passed\n\nThe vector zero-length warning printed by testSetLengthSq is deliberate test behavior and remains unchanged.