### PR TITLE
fix: register benchmark annotation

### DIFF
--- a/wurst/_wurst/Annotations.wurst
+++ b/wurst/_wurst/Annotations.wurst
@@ -11,6 +11,9 @@ import NoWurst
 /** This annotation means that this function will be executed when the map is compiled. */
 @annotation public function compiletime()
 
+/** Functions annotated with @benchmark can be measured by the benchmark runner. */
+@annotation public function benchmark()
+
 /** This annotation means that this function should no longer be used. */
 @annotation public function deprecated()
 


### PR DESCRIPTION
Registers `@benchmark` as a built-in stdlib annotation for the benchmark runner introduced by wurstscript/WurstScript#1218 and wurstscript/WurstSetup#75.

Without this declaration, valid benchmark sources compile but emit an undefined-annotation warning. A function may intentionally carry both `@test` and `@benchmark`, so the same deterministic workload can serve as correctness coverage and as a benchmark.

This PR changes no Polygon implementation or existing API. PR #454 already contains the optimized Polygon classifier.

Verification from `nix develop /home/daniel/Repositories/tever/tever_main`:

- stdlib typecheck passed;
- full quiet stdlib test suite passed;
- targeted `PolygonTests` passed 22/22;
- compilation summary: 0 errors, 0 warnings;
- real dual-tagged Polygon benchmark returned checksum 7907 for both implementations across 5 forks × 20 samples.
