### PR TITLE
Fix default DamageEvent listener priority

### DIFF
--- a/wurst/StdlibIngameTests.wurst
+++ b/wurst/StdlibIngameTests.wurst
@@ -371,6 +371,60 @@ function testNestedZeroedDamage()
 	destroy rl
 
 // ============================================================================
+// 11. A late default listener must remain at the default priority
+// ============================================================================
+
+var lateDefaultReducedAmount = -1.
+
+function testLateDefaultReducedListenerPriority()
+	section("--- 11. late default reduced listener stays before priority 100 ---")
+	lateDefaultReducedAmount = -1.
+
+	// Register the observer first: production systems commonly initialize a
+	// final observer before gameplay installs short-lived modifiers.
+	let observer = DamageEvent.addListener(100) ->
+		lateDefaultReducedAmount = DamageEvent.getAmount()
+	let modifier = DamageEvent.addListener() ->
+		// Expected: no-priority means priority 0, so this changes 100 to 40
+		// before the already-registered priority-100 observer runs.
+		DamageEvent.setAmount(40.)
+
+	DamageEvent.setNextDamageFromCode()
+	attacker.damageTarget(victim, 100.)
+
+	check(lateDefaultReducedAmount == 40., "late default reduced listener: expected 40.0, actual "
+		+ lateDefaultReducedAmount.toString(1))
+
+	destroy observer
+	destroy modifier
+
+// ============================================================================
+// 12. The same default-priority contract applies before native reduction
+// ============================================================================
+
+var lateDefaultUnreducedAmount = -1.
+
+function testLateDefaultUnreducedListenerPriority()
+	section("--- 12. late default unreduced listener stays before priority 100 ---")
+	lateDefaultUnreducedAmount = -1.
+
+	let observer = DamageEvent.addUnreducedListener(100) ->
+		lateDefaultUnreducedAmount = DamageEvent.getAmount()
+	let modifier = DamageEvent.addUnreducedListener() ->
+		// Expected: the default-priority modifier runs first and the explicit
+		// priority-100 observer reads its live value of 40 rather than 100.
+		DamageEvent.setAmount(40.)
+
+	DamageEvent.setNextDamageFromCode()
+	attacker.damageTarget(victim, 100.)
+
+	check(lateDefaultUnreducedAmount == 40., "late default unreduced listener: expected 40.0, actual "
+		+ lateDefaultUnreducedAmount.toString(1))
+
+	destroy observer
+	destroy modifier
+
+// ============================================================================
 // 7. Nested group enumeration
 // ============================================================================
 
@@ -464,6 +518,10 @@ public function runStdlibIngameTests()
 		testSelfDestroyingListener()
 	runGuarded("10. zeroed nested hit") ->
 		testNestedZeroedDamage()
+	runGuarded("11. late default reduced listener") ->
+		testLateDefaultReducedListenerPriority()
+	runGuarded("12. late default unreduced listener") ->
+		testLateDefaultUnreducedListenerPriority()
 	runGuarded("teardown") ->
 		teardownUnits()
 

--- a/wurst/event/DamageEvent.wurst
+++ b/wurst/event/DamageEvent.wurst
@@ -302,10 +302,10 @@ public class DamageEvent
 
 
     /* LISTENERS */
-    /** Adds a damage event listener at the current highest registered priority.
+    /** Adds a damage event listener at priority 0.
         If the order of firing is important, use addListener(priority, listener) */
     static function addListener(DamageListener listener) returns DamageListener
-        return addListener(maxPriority, listener)
+        return addListener(0, listener)
 
     /** Adds a damage event listener with a given priority.
         Listeners of different priorities fire from the lowest priority to the highest priority added.
@@ -357,10 +357,10 @@ public class DamageEvent
                 p--
             maxPriority = p
 
-    /** Adds a damage event listener that fires before any damage reduction is applied (such as armor).
-    If the order of firing is important, use addUnreducedListener(priority, listener) */
+    /** Adds a damage event listener at priority 0 that fires before any damage reduction is applied
+        (such as armor). If the order of firing is important, use addUnreducedListener(priority, listener) */
     static function addUnreducedListener(DamageListener listener) returns DamageListener
-        return addUnreducedListener(maxUnreducedPriority, listener)
+        return addUnreducedListener(0, listener)
 
     /** Adds a damage event listener with a given priority that fires before any damage reduction is applied (such as armor).
         Listeners of different priorities fire from the lowest priority to the highest priority added.


### PR DESCRIPTION
## What changed

- Make the no-priority `DamageEvent.addListener(listener)` overload register at priority 0.
- Apply the same contract to `addUnreducedListener(listener)`.
- Add in-game regressions for a default modifier installed after an explicit priority-100 observer.

## Root cause

Commit 8cbe5b9 correctly changed same-priority traversal to FIFO, but the no-priority overload still used the current maximum registered priority. If a final observer registered at priority 100 during initialization, a gameplay modifier installed later without an explicit priority silently became priority 100 as well. FIFO then ran the earlier observer first, so it read the raw amount even though the modifier ran afterward.

This is a live-gameplay pipeline issue, not only a test failure: damage observers such as statistics, shields, and chained effects can consume the unmodified amount when dynamically registered modifiers are unintentionally promoted to their priority. The engine still receives the modifier's final amount after traversal, but downstream listener state can be wrong.

The FIFO/tail-pointer and nested cursor work remains intact.

## Verification

- `grill typecheck --quiet`
- `grill test --quiet`
- Warcraft III in-game regression:
  - 8cbe5b9: reduced 100.0, unreduced 100.0; 21/23 checks
  - 8cbe5b9~1: reduced 40.0, unreduced 40.0
  - fixed branch: reduced 40.0, unreduced 40.0; 23/23 checks
