### PR TITLE
Add versioned compiler-assisted serialization

### DIFF
--- a/wurst/_wurst/Annotations.wurst
+++ b/wurst/_wurst/Annotations.wurst
@@ -21,6 +21,14 @@ import NoWurst
 /** Functions annotated with @compiletimenative are natives that are only available at compiletime, but not ingame.  */
 @annotation public function compiletimenative()
 
+/**
+Marks a documented declaration whose calls are expanded by the compiler.
+
+Unlike a normal fallback declaration, this does not suppress intrinsic lowering. The declaration
+exists so intrinsic APIs remain visible to completion, navigation, and documentation tools.
+*/
+@annotation public function compilerintrinsic()
+
 /** Elements annotated with @configurable can be configured (i.e. replaced by a different implementation) in configuration packages.  */
 @annotation public function configurable()
 

--- a/wurst/_wurst/MagicFunctions.wurst
+++ b/wurst/_wurst/MagicFunctions.wurst
@@ -48,3 +48,26 @@ public constant isLua = false
  */
  public function compiletime<T:>(T expr) returns T
 	 return expr
+
+/*
+Compiler intrinsics for field-wise code generation and generic construction:
+
+```
+forFields((fieldName, value) -> writer.write(fieldName, value))
+forFields(target, (fieldName, value) -> writer.write(fieldName, value))
+mapFields((fieldName, value) -> reader.read(fieldName, value))
+mapFields(target, (fieldName, value) -> reader.read(fieldName, value))
+let value = newInstance<MyClass>()
+```
+
+`forFields` emits the callback once for every accessible non-static instance field.
+`mapFields` assigns each callback result back to the corresponding mutable field.
+The forms without a target operate on the enclosing class instance. Explicit targets are
+evaluated once. `newInstance<T>()` invokes the accessible zero-argument constructor of the
+concrete class supplied as `T`.
+
+These calls are recognized by the compiler when no applicable user-defined overload exists.
+They intentionally have no Wurst declarations here: declaring matching functions would turn
+them into ordinary calls and suppress intrinsic expansion. All three compile to direct
+construction and field access without runtime reflection or metadata.
+*/

--- a/wurst/_wurst/MagicFunctions.wurst
+++ b/wurst/_wurst/MagicFunctions.wurst
@@ -69,12 +69,28 @@ Use the explicit-target form `wurstForFields(target, callback)` for classes and 
 @compilerintrinsic public function wurstForFields(WurstFieldCallback _callback)
 
 /**
+Emits the callback once for every accessible non-static field of `target`.
+
+This overload supports class instances and tuple values. The target expression is evaluated
+once, and the compiler specializes the callback value to each field's concrete type.
+*/
+@compilerintrinsic public function wurstForFields<T:>(T _target, WurstFieldCallback _callback)
+
+/**
 Maps every accessible mutable non-static field of the enclosing class.
 
 Each callback result is assigned back to its field. Use the explicit-target form
 `wurstMapFields(target, callback)` for classes and tuple variables.
 */
 @compilerintrinsic public function wurstMapFields(WurstFieldMapper _callback)
+
+/**
+Maps every accessible mutable non-static field of `target`.
+
+This overload supports class instances and tuple variables. The target expression is evaluated
+once, and each specialized callback result is assigned directly back to its field.
+*/
+@compilerintrinsic public function wurstMapFields<T:>(T _target, WurstFieldMapper _callback)
 
 /**
 Constructs the concrete class `T` through its accessible zero-argument constructor.

--- a/wurst/_wurst/MagicFunctions.wurst
+++ b/wurst/_wurst/MagicFunctions.wurst
@@ -49,25 +49,38 @@ public constant isLua = false
  public function compiletime<T:>(T expr) returns T
 	 return expr
 
-/*
-Compiler intrinsics for field-wise code generation and generic construction:
+/** Tooling signature used by the field-iteration compiler intrinsics.
+The compiler specializes `value` to the concrete type of each visited field. */
+public interface WurstFieldCallback
+	function apply(string fieldName, int value)
 
-```
-forFields((fieldName, value) -> writer.write(fieldName, value))
-forFields(target, (fieldName, value) -> writer.write(fieldName, value))
-mapFields((fieldName, value) -> reader.read(fieldName, value))
-mapFields(target, (fieldName, value) -> reader.read(fieldName, value))
-let value = newInstance<MyClass>()
-```
+/** Tooling signature used by the field-mapping compiler intrinsic.
+The compiler specializes both the parameter and result to each concrete field type. */
+public interface WurstFieldMapper
+	function apply(string fieldName, int value) returns int
 
-`forFields` emits the callback once for every accessible non-static instance field.
-`mapFields` assigns each callback result back to the corresponding mutable field.
-The forms without a target operate on the enclosing class instance. Explicit targets are
-evaluated once. `newInstance<T>()` invokes the accessible zero-argument constructor of the
-concrete class supplied as `T`.
+/**
+Emits the callback once for every accessible non-static field of the enclosing class.
 
-These calls are recognized by the compiler when no applicable user-defined overload exists.
-They intentionally have no Wurst declarations here: declaring matching functions would turn
-them into ordinary calls and suppress intrinsic expansion. All three compile to direct
-construction and field access without runtime reflection or metadata.
+The callback receives the source field name and its concrete value. This is compile-time code
+generation: the generated Jass or Lua contains direct field accesses and no runtime reflection.
+Use the explicit-target form `wurstForFields(target, callback)` for classes and tuples.
 */
+@compilerintrinsic public function wurstForFields(WurstFieldCallback _callback)
+
+/**
+Maps every accessible mutable non-static field of the enclosing class.
+
+Each callback result is assigned back to its field. Use the explicit-target form
+`wurstMapFields(target, callback)` for classes and tuple variables.
+*/
+@compilerintrinsic public function wurstMapFields(WurstFieldMapper _callback)
+
+/**
+Constructs the concrete class `T` through its accessible zero-argument constructor.
+
+This is an intrinsic rather than runtime reflection. Consequently `T` must be known concretely
+at the call site and normal constructor visibility and abstract-class checks still apply.
+*/
+@compilerintrinsic public function wurstNewInstance<T:>() returns T
+	return null

--- a/wurst/_wurst/MagicFunctionsTests.wurst
+++ b/wurst/_wurst/MagicFunctionsTests.wurst
@@ -1,0 +1,33 @@
+package MagicFunctionsTests
+import MagicFunctions
+import Wurstunit
+
+int visitedFieldTotal = 0
+
+tuple IntrinsicTargetTuple(int left, int right)
+
+class IntrinsicTargetClass
+	int left = 2
+	int right = 5
+
+function addVisitedField(string _name, int value)
+	visitedFieldTotal += value
+
+@Test
+function explicitTargetFieldIntrinsicsSupportClassesAndTuples()
+	visitedFieldTotal = 0
+	let target = new IntrinsicTargetClass()
+	var tupleTarget = IntrinsicTargetTuple(11, 13)
+
+	wurstForFields(target, (name, value) -> addVisitedField(name, value))
+	wurstMapFields(target, (name, value) -> value + 1)
+	wurstForFields(tupleTarget, (name, value) -> addVisitedField(name, value))
+	wurstMapFields(tupleTarget, (name, value) -> value + 2)
+
+	visitedFieldTotal.assertEquals(31)
+	target.left.assertEquals(3)
+	target.right.assertEquals(6)
+	tupleTarget.left.assertEquals(13)
+	tupleTarget.right.assertEquals(15)
+
+	destroy target

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -34,10 +34,10 @@ import ErrorHandling
 
 	Readonly and constant fields can be written by the compiler intrinsic but cannot be restored.
 	Nested class fields must be initialized (non-null). Custom tuples and other application types
-	must provide writer, reader, and `readSerializedField` overloads; the `StructuredSerialization`
-	package documentation contains a complete custom-tuple example using `wurstForFields` and
-	`wurstMapFields`. Exact nullable construction and generic collection codecs still need compiler
-	support.
+	must provide writer, reader, and `readSerializedField` overloads. Their owning DAO should use
+	`FieldSerializableLifecycle` and declare its intrinsic field mapping beside those overloads. The
+	`StructuredSerialization` package documentation contains a complete example. Exact nullable
+	construction and generic collection codecs still need compiler support.
 
 	The legacy `Serializable` base class below retains its original verbose RLE format for backwards
 	compatibility. Do not use it for new save formats.

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -7,17 +7,15 @@ import ErrorHandling
 	Allows you to save properties of any class instance into a string,
 	and load the same properties from that string.
 
-	Properties are saved in plain text format, but hashed to prevent naive tampering.
-	If the saved properties are meant to be private, you should pipe the output through an encoder.
-
 	=>MODERN USAGE<=
 
-	For dedicated state classes, use `SerializableFields`. It generates direct field accesses at
-	compile time, so fields do not need to be listed manually and no runtime reflection is used.
-	The class must have an accessible zero-argument constructor, and its serializable fields must
-	be mutable `int`, `real`, `string`, or `boolean` instance fields with names up to 10 characters.
+	For new code, import the separate `StructuredSerialization` package, implement
+	`FieldSerializable`, and use `SerializableFields`. It
+	generates direct field accesses at compile time, so fields do not need to be listed manually and
+	no runtime reflection is used. Primitive fields, standard tuples, and nested opted-in classes
+	are composable through type-specific writer/reader overloads.
 
-		> class MyClass
+		> class MyClass implements FieldSerializable
 		> 	use SerializableFields
 		> 	int amount = 0
 		> 	string name = ""
@@ -27,12 +25,20 @@ import ErrorHandling
 
 	`load` returns the correctly typed instance for concise construction and chaining. `deserialize`
 	can instead update an existing instance and returns whether the input passed its integrity check.
-	Constructor defaults are preserved for fields missing from older save data. Unknown fields from
-	newer save data are ignored. Keep persisted state in a small, focused class; renaming a field
-	changes its save key.
+	The modern format is compact, tagged, versioned, and protected by a keyed rolling integrity hash
+	by default. Constructor defaults are preserved for missing fields and unknown fields are ignored.
+	Field order is irrelevant. Pass a schema version to `serialize`, and use a
+	`SerializationMigration` to rename fields or transform older schemas before assignment. Override
+	`SERIALIZATION_INTEGRITY_KEY` with a private map-specific value to deter players editing saves.
+	This is tamper resistance, not cryptographic secrecy against map-script inspection.
 
-	Readonly and constant fields can be written by the compiler intrinsic but cannot be restored, so
-	they are not supported by `SerializableFields`. Other field types should be serialized manually.
+	Readonly and constant fields can be written by the compiler intrinsic but cannot be restored.
+	Nested class fields must be initialized (non-null). Unsupported application types should provide
+	`FieldSerializationWriter.write` and `readSerializedField` overloads, like the standard tuple
+	codecs do. Exact nullable construction and generic collection codecs still need compiler support.
+
+	The legacy `Serializable` base class below retains its original verbose RLE format for backwards
+	compatibility. Do not use it for new save formats.
 
 	=>LEGACY USAGE<=
 
@@ -82,156 +88,6 @@ constant HASH_LENGTH = 10
 constant INT_TOKEN = "i"
 constant REAL_TOKEN = "r"
 constant STRING_TOKEN = "s"
-constant BOOLEAN_TOKEN = "b"
-
-function int.padSerializationHash() returns string
-    var hashString = this.toString()
-    if hashString.length() > HASH_LENGTH
-        hashString = hashString.substring(0, HASH_LENGTH)
-    while hashString.length() < HASH_LENGTH
-        hashString = "0" + hashString
-    return hashString
-
-class FieldSerializationWriter
-    private let output = new ChunkedString()
-    private int hash = 0
-
-    private function write(string name, string token, string value)
-        if name.length() > MAX_NAME_LENGTH
-            error("name " + name + " too long.")
-
-        let property = name + "=" + value
-        var propertyLength = property.length().toString()
-        while propertyLength.length() < LEN_LENGTH
-            propertyLength = "0" + propertyLength
-
-        hash += property.getHash()
-        output.append(token + propertyLength + property)
-
-    function write(string name, int value)
-        write(name, INT_TOKEN, value.toString())
-
-    function write(string name, real value)
-        write(name, REAL_TOKEN, value.toString())
-
-    function write(string name, string value)
-        write(name, STRING_TOKEN, value)
-
-    function write(string name, boolean value)
-        write(name, BOOLEAN_TOKEN, value.toString())
-
-    function finish() returns ChunkedString
-        output.append(hash.padSerializationHash())
-        return output
-
-class FieldSerializationReader
-    private let intMap = new HashMap<int, int>()
-    private let realMap = new HashMap<int, real>()
-    private let stringMap = new HashMap<int, string>()
-    private let booleanMap = new HashMap<int, boolean>()
-    private int hash = 0
-    private boolean valid = false
-
-    construct(ChunkedString input)
-        if input.length() >= HASH_LENGTH
-            var pointer = 0
-            let dataLength = input.length() - HASH_LENGTH
-            var parsing = true
-            while pointer < dataLength and parsing
-                if pointer + 1 + LEN_LENGTH > dataLength
-                    parsing = false
-                else
-                    let token = input.getUnsafeSubString(pointer, pointer + 1)
-                    if token != INT_TOKEN and token != REAL_TOKEN and token != STRING_TOKEN and token != BOOLEAN_TOKEN
-                        parsing = false
-                    else
-                        pointer += 1
-                        let length = input.getUnsafeSubString(pointer, pointer + LEN_LENGTH).toInt()
-                        pointer += LEN_LENGTH
-                        if length <= 0 or pointer + length > dataLength
-                            parsing = false
-                        else
-                            parsing = parseProperty(token, input.getUnsafeSubString(pointer, pointer + length))
-                            pointer += length
-
-            if parsing
-                valid = input.getUnsafeSubString(dataLength, input.length()) == hash.padSerializationHash()
-
-    private function parseProperty(string token, string input) returns boolean
-        let indexOfEqual = input.indexOf("=")
-        if indexOfEqual <= 0
-            return false
-
-        hash += input.getHash()
-        let name = input.substring(0, indexOfEqual).getHash()
-        let value = input.substring(indexOfEqual + 1)
-        switch token
-            case INT_TOKEN
-                intMap.put(name, value.toInt())
-            case REAL_TOKEN
-                realMap.put(name, value.toReal())
-            case STRING_TOKEN
-                stringMap.put(name, value)
-            case BOOLEAN_TOKEN
-                booleanMap.put(name, value.toBool())
-        return true
-
-    function isValid() returns boolean
-        return valid
-
-    function read(string name, int oldValue) returns int
-        let key = name.getHash()
-        return intMap.has(key) ? intMap.get(key) : oldValue
-
-    function read(string name, real oldValue) returns real
-        let key = name.getHash()
-        return realMap.has(key) ? realMap.get(key) : oldValue
-
-    function read(string name, string oldValue) returns string
-        let key = name.getHash()
-        return stringMap.has(key) ? stringMap.get(key) : oldValue
-
-    function read(string name, boolean oldValue) returns boolean
-        let key = name.getHash()
-        return booleanMap.has(key) ? booleanMap.get(key) : oldValue
-
-    ondestroy
-        destroy intMap
-        destroy realMap
-        destroy stringMap
-        destroy booleanMap
-
-/**
-Automatically serializes the mutable primitive instance fields of a dedicated state class.
-
-Use this module instead of extending `Serializable` for new code. Serialization is expanded to
-direct field accesses at compile time and works on both the Jass and Lua backends.
-*/
-public module SerializableFields
-    /** Serializes all supported instance fields and returns the encoded data. */
-    function serialize() returns ChunkedString
-        let writer = new FieldSerializationWriter()
-        forFields((fieldName, value) -> writer.write(fieldName, value))
-        let result = writer.finish()
-        destroy writer
-        return result
-
-    /**
-    Populates this instance from encoded data and returns whether its integrity check succeeded.
-    Missing fields retain their current values. No fields are changed when validation fails.
-    */
-    function deserialize(ChunkedString input) returns boolean
-        let reader = new FieldSerializationReader(input)
-        let result = reader.isValid()
-        if result
-            mapFields((fieldName, value) -> reader.read(fieldName, value))
-        destroy reader
-        return result
-
-    /** Loads encoded data into this instance and returns it for concise construction and chaining. */
-    function load(ChunkedString input) returns thistype
-        deserialize(input)
-        return this
 
 public abstract class Serializable
     private ChunkedString serOutput = null

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -84,10 +84,20 @@ import ErrorHandling
 constant MAX_NAME_LENGTH = 10
 constant LEN_LENGTH = 3
 constant HASH_LENGTH = 10
+constant MAX_PROPERTY_LENGTH = 999
 
 constant INT_TOKEN = "i"
 constant REAL_TOKEN = "r"
 constant STRING_TOKEN = "s"
+
+function isValidLegacyProperty(string name, string property) returns boolean
+    if name.length() > MAX_NAME_LENGTH
+        error("name " + name + " too long.")
+        return false
+    if property.length() > MAX_PROPERTY_LENGTH
+        error("property " + name + " exceeds the legacy format's 999-byte limit.")
+        return false
+    return true
 
 public abstract class Serializable
     private ChunkedString serOutput = null
@@ -97,10 +107,9 @@ public abstract class Serializable
     var hash = 0
 
     function addProperty(string name, int value)
-        if name.length() > MAX_NAME_LENGTH
-            error("name " + name + " too long.")
-
         let prop = name + "=" + value
+        if not isValidLegacyProperty(name, prop)
+            return
         var propLen = prop.length().toString()
         while propLen.length() < LEN_LENGTH
             propLen = "0" + propLen
@@ -109,10 +118,9 @@ public abstract class Serializable
         serOutput.append(INT_TOKEN + propLen + prop)
 
     function addProperty(string name, real value)
-        if name.length() > MAX_NAME_LENGTH
-            error("name " + name + " too long.")
-
         let prop = name + "=" + value
+        if not isValidLegacyProperty(name, prop)
+            return
         var propLen = prop.length().toString()
         while propLen.length() < LEN_LENGTH
             propLen = "0" + propLen
@@ -121,10 +129,9 @@ public abstract class Serializable
         serOutput.append(REAL_TOKEN + propLen + prop)
 
     function addProperty(string name, string value)
-        if name.length() > MAX_NAME_LENGTH
-            error("name " + name + " too long.")
-
         let prop = name + "=" + value
+        if not isValidLegacyProperty(name, prop)
+            return
         var propLen = prop.length().toString()
         while propLen.length() < LEN_LENGTH
             propLen = "0" + propLen

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -8,9 +8,33 @@ import ErrorHandling
 	and load the same properties from that string.
 
 	Properties are saved in plain text format, but hashed to prevent naive tampering.
-	If the saved properties are meant to be private, you should pripe the output through an encoder.
+	If the saved properties are meant to be private, you should pipe the output through an encoder.
 
-	=>USAGE<=
+	=>MODERN USAGE<=
+
+	For dedicated state classes, use `SerializableFields`. It generates direct field accesses at
+	compile time, so fields do not need to be listed manually and no runtime reflection is used.
+	The class must have an accessible zero-argument constructor, and its serializable fields must
+	be mutable `int`, `real`, `string`, or `boolean` instance fields with names up to 10 characters.
+
+		> class MyClass
+		> 	use SerializableFields
+		> 	int amount = 0
+		> 	string name = ""
+
+		> let data = myClass.serialize()
+		> let loaded = new MyClass().load(data)
+
+	`load` returns the correctly typed instance for concise construction and chaining. `deserialize`
+	can instead update an existing instance and returns whether the input passed its integrity check.
+	Constructor defaults are preserved for fields missing from older save data. Unknown fields from
+	newer save data are ignored. Keep persisted state in a small, focused class; renaming a field
+	changes its save key.
+
+	Readonly and constant fields can be written by the compiler intrinsic but cannot be restored, so
+	they are not supported by `SerializableFields`. Other field types should be serialized manually.
+
+	=>LEGACY USAGE<=
 
 	1. Make your class extend the Serializable abstract class
 
@@ -58,6 +82,156 @@ constant HASH_LENGTH = 10
 constant INT_TOKEN = "i"
 constant REAL_TOKEN = "r"
 constant STRING_TOKEN = "s"
+constant BOOLEAN_TOKEN = "b"
+
+function int.padSerializationHash() returns string
+    var hashString = this.toString()
+    if hashString.length() > HASH_LENGTH
+        hashString = hashString.substring(0, HASH_LENGTH)
+    while hashString.length() < HASH_LENGTH
+        hashString = "0" + hashString
+    return hashString
+
+class FieldSerializationWriter
+    private let output = new ChunkedString()
+    private int hash = 0
+
+    private function write(string name, string token, string value)
+        if name.length() > MAX_NAME_LENGTH
+            error("name " + name + " too long.")
+
+        let property = name + "=" + value
+        var propertyLength = property.length().toString()
+        while propertyLength.length() < LEN_LENGTH
+            propertyLength = "0" + propertyLength
+
+        hash += property.getHash()
+        output.append(token + propertyLength + property)
+
+    function write(string name, int value)
+        write(name, INT_TOKEN, value.toString())
+
+    function write(string name, real value)
+        write(name, REAL_TOKEN, value.toString())
+
+    function write(string name, string value)
+        write(name, STRING_TOKEN, value)
+
+    function write(string name, boolean value)
+        write(name, BOOLEAN_TOKEN, value.toString())
+
+    function finish() returns ChunkedString
+        output.append(hash.padSerializationHash())
+        return output
+
+class FieldSerializationReader
+    private let intMap = new HashMap<int, int>()
+    private let realMap = new HashMap<int, real>()
+    private let stringMap = new HashMap<int, string>()
+    private let booleanMap = new HashMap<int, boolean>()
+    private int hash = 0
+    private boolean valid = false
+
+    construct(ChunkedString input)
+        if input.length() >= HASH_LENGTH
+            var pointer = 0
+            let dataLength = input.length() - HASH_LENGTH
+            var parsing = true
+            while pointer < dataLength and parsing
+                if pointer + 1 + LEN_LENGTH > dataLength
+                    parsing = false
+                else
+                    let token = input.getUnsafeSubString(pointer, pointer + 1)
+                    if token != INT_TOKEN and token != REAL_TOKEN and token != STRING_TOKEN and token != BOOLEAN_TOKEN
+                        parsing = false
+                    else
+                        pointer += 1
+                        let length = input.getUnsafeSubString(pointer, pointer + LEN_LENGTH).toInt()
+                        pointer += LEN_LENGTH
+                        if length <= 0 or pointer + length > dataLength
+                            parsing = false
+                        else
+                            parsing = parseProperty(token, input.getUnsafeSubString(pointer, pointer + length))
+                            pointer += length
+
+            if parsing
+                valid = input.getUnsafeSubString(dataLength, input.length()) == hash.padSerializationHash()
+
+    private function parseProperty(string token, string input) returns boolean
+        let indexOfEqual = input.indexOf("=")
+        if indexOfEqual <= 0
+            return false
+
+        hash += input.getHash()
+        let name = input.substring(0, indexOfEqual).getHash()
+        let value = input.substring(indexOfEqual + 1)
+        switch token
+            case INT_TOKEN
+                intMap.put(name, value.toInt())
+            case REAL_TOKEN
+                realMap.put(name, value.toReal())
+            case STRING_TOKEN
+                stringMap.put(name, value)
+            case BOOLEAN_TOKEN
+                booleanMap.put(name, value.toBool())
+        return true
+
+    function isValid() returns boolean
+        return valid
+
+    function read(string name, int oldValue) returns int
+        let key = name.getHash()
+        return intMap.has(key) ? intMap.get(key) : oldValue
+
+    function read(string name, real oldValue) returns real
+        let key = name.getHash()
+        return realMap.has(key) ? realMap.get(key) : oldValue
+
+    function read(string name, string oldValue) returns string
+        let key = name.getHash()
+        return stringMap.has(key) ? stringMap.get(key) : oldValue
+
+    function read(string name, boolean oldValue) returns boolean
+        let key = name.getHash()
+        return booleanMap.has(key) ? booleanMap.get(key) : oldValue
+
+    ondestroy
+        destroy intMap
+        destroy realMap
+        destroy stringMap
+        destroy booleanMap
+
+/**
+Automatically serializes the mutable primitive instance fields of a dedicated state class.
+
+Use this module instead of extending `Serializable` for new code. Serialization is expanded to
+direct field accesses at compile time and works on both the Jass and Lua backends.
+*/
+public module SerializableFields
+    /** Serializes all supported instance fields and returns the encoded data. */
+    function serialize() returns ChunkedString
+        let writer = new FieldSerializationWriter()
+        forFields((fieldName, value) -> writer.write(fieldName, value))
+        let result = writer.finish()
+        destroy writer
+        return result
+
+    /**
+    Populates this instance from encoded data and returns whether its integrity check succeeded.
+    Missing fields retain their current values. No fields are changed when validation fails.
+    */
+    function deserialize(ChunkedString input) returns boolean
+        let reader = new FieldSerializationReader(input)
+        let result = reader.isValid()
+        if result
+            mapFields((fieldName, value) -> reader.read(fieldName, value))
+        destroy reader
+        return result
+
+    /** Loads encoded data into this instance and returns it for concise construction and chaining. */
+    function load(ChunkedString input) returns thistype
+        deserialize(input)
+        return this
 
 public abstract class Serializable
     private ChunkedString serOutput = null

--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -33,9 +33,11 @@ import ErrorHandling
 	This is tamper resistance, not cryptographic secrecy against map-script inspection.
 
 	Readonly and constant fields can be written by the compiler intrinsic but cannot be restored.
-	Nested class fields must be initialized (non-null). Unsupported application types should provide
-	`FieldSerializationWriter.write` and `readSerializedField` overloads, like the standard tuple
-	codecs do. Exact nullable construction and generic collection codecs still need compiler support.
+	Nested class fields must be initialized (non-null). Custom tuples and other application types
+	must provide writer, reader, and `readSerializedField` overloads; the `StructuredSerialization`
+	package documentation contains a complete custom-tuple example using `wurstForFields` and
+	`wurstMapFields`. Exact nullable construction and generic collection codecs still need compiler
+	support.
 
 	The legacy `Serializable` base class below retains its original verbose RLE format for backwards
 	compatibility. Do not use it for new save formats.

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -6,6 +6,12 @@ import Vectors
 
 int constructions = 0
 
+function repeated(string value, int count) returns string
+	var result = ""
+	for _i = 1 to count
+		result += value
+	return result
+
 class ChildState implements FieldSerializable
 	use SerializableFields
 
@@ -24,6 +30,24 @@ class PlayerState implements FieldSerializable
 
 	construct()
 		constructions++
+
+	ondestroy
+		destroy child
+
+class LargeChildState implements FieldSerializable
+	use SerializableFields
+
+	string first = ""
+	string second = ""
+	string third = ""
+	string fourth = ""
+	string fifth = ""
+	string sixth = ""
+
+class LargeParentState implements FieldSerializable
+	use SerializableFields
+
+	LargeChildState child = new LargeChildState()
 
 	ondestroy
 		destroy child
@@ -127,7 +151,11 @@ function integrityKeyRejectsEditedOrForeignDataWithoutMutation()
 	let edited = new ChunkedString()..append("X" + encoded.substring(1))
 	state.deserialize(edited, 12345).assertFalse()
 	state.score.assertEquals(1)
+	let editedToken = new ChunkedString()..append(encoded.substring(0, 11) + "r" + encoded.substring(12))
+	state.deserialize(editedToken, 12345).assertFalse()
+	state.score.assertEquals(1)
 
+	destroy editedToken
 	destroy edited
 	destroy state
 	destroy data
@@ -172,6 +200,48 @@ function signedIntegerCodecPreservesFullWidthValues()
 	destroy reader
 	destroy data
 	destroy writer
+
+@Test
+function varUIntContinuationAlphabetHandlesAllFiveBitGroups()
+	for length = 60 to 63
+		let expected = repeated("x", length)
+		let writer = new FieldSerializationWriter(1)
+		writer.write("value", expected)
+		let data = writer.finish()
+		let reader = new FieldSerializationReader(data)
+
+		reader.isValid().assertTrue()
+		reader.read("value", "").assertEquals(expected)
+
+		destroy reader
+		destroy data
+		destroy writer
+
+@Test
+function nestedEnvelopesRemainChunkedBeyondOneRuntimeString()
+	let original = new LargeParentState()
+	original.child.first = repeated("a", 180)
+	original.child.second = repeated("b", 180)
+	original.child.third = repeated("c", 180)
+	original.child.fourth = repeated("d", 180)
+	original.child.fifth = repeated("e", 180)
+	original.child.sixth = repeated("f", 180)
+
+	let data = original.serialize()
+	(data.length() > 1000).assertTrue()
+	(data.getChunkCount() > 1).assertTrue()
+	let loaded = new LargeParentState()
+	loaded.deserialize(data).assertTrue()
+	loaded.child.first.assertEquals(original.child.first)
+	loaded.child.second.assertEquals(original.child.second)
+	loaded.child.third.assertEquals(original.child.third)
+	loaded.child.fourth.assertEquals(original.child.fourth)
+	loaded.child.fifth.assertEquals(original.child.fifth)
+	loaded.child.sixth.assertEquals(original.child.sixth)
+
+	destroy loaded
+	destroy data
+	destroy original
 
 @Test
 function legacySerializableStillRoundTripsItsOriginalFormat()

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -71,9 +71,15 @@ class LargeParentState implements FieldSerializable
 		destroy child
 
 class CustomTupleState implements FieldSerializable
-	use SerializableFields
+	use FieldSerializableLifecycle
 
 	InventorySlot slot = InventorySlot(0, 0)
+
+	override function writeSerializedFields(FieldSerializationWriter writer)
+		wurstForFields((fieldName, fieldValue) -> writer.write(fieldName, fieldValue))
+
+	override function readSerializedFields(FieldSerializationReader reader)
+		wurstMapFields((fieldName, fieldValue) -> fieldValue.readSerializedField(reader, fieldName))
 
 class RenameScore implements SerializationMigration
 	override function migrate(FieldSerializationReader reader)
@@ -128,6 +134,12 @@ function customTupleCodecRoundTripsThroughSerializableFields()
 	original.slot = InventorySlot(1234, 7)
 
 	let data = original.serialize()
+	let rootReader = new FieldSerializationReader(data)
+	rootReader.hasField("slot").assertTrue()
+	let tupleReader = rootReader.readObject("slot")
+	tupleReader.hasField("itemId").assertTrue()
+	int defaultItemId = 0
+	tupleReader.read("itemId", defaultItemId).assertEquals(1234)
 	let loaded = new CustomTupleState().load(data)
 
 	loaded.slot.itemId.assertEquals(1234)
@@ -135,6 +147,8 @@ function customTupleCodecRoundTripsThroughSerializableFields()
 
 	destroy original
 	destroy loaded
+	destroy tupleReader
+	destroy rootReader
 	destroy data
 
 @Test

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -296,6 +296,33 @@ function rawChunkedPayloadCanBeReadWithoutFlattening()
 	destroy decoded
 
 @Test
+function unicodeHashingIsIndependentOfChunkBoundaries()
+	let unicodePart = "Würst世界🙂"
+	var expected = ""
+	let payload = new ChunkedString(37)
+	for _i = 1 to 40
+		expected += unicodePart
+		payload.append(unicodePart)
+
+	let writer = new FieldSerializationWriter(1)
+	writer.writeRaw("Ünicode字段", "u", payload)
+	let data = writer.finish()
+	let reader = new FieldSerializationReader(data)
+	let decoded = reader.readRawChunked("Ünicode字段", "u")
+
+	reader.isValid().assertTrue()
+	decoded.length().assertEquals(expected.length())
+	decoded.getUnsafeString().assertEquals(expected)
+	for i = 0 to decoded.getChunkCount() - 1
+		(decoded.getChunk(i).length() <= decoded.getChunkSize() + 3).assertTrue()
+
+	destroy decoded
+	destroy reader
+	destroy data
+	destroy writer
+	destroy payload
+
+@Test
 function legacySerializableStillRoundTripsItsOriginalFormat()
 	let original = new OldPlayerState()
 	original.score = 11

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -202,6 +202,28 @@ function signedIntegerCodecPreservesFullWidthValues()
 	destroy writer
 
 @Test
+function realCodecPreservesSignificantIntegerZeroes()
+	let writer = new FieldSerializationWriter(1)
+	writer.write("ten", 10.)
+	writer.write("zero", 0.)
+	let data = writer.finish()
+	let reader = new FieldSerializationReader(data)
+
+	reader.isValid().assertTrue()
+	reader.read("ten", -1.).assertEquals(10.)
+	reader.read("zero", -1.).assertEquals(0.)
+
+	destroy reader
+	destroy data
+	destroy writer
+
+@Test
+function unfinishedWriterCanBeDestroyedSafely()
+	let writer = new FieldSerializationWriter(1)
+	writer.write("partial", "discarded")
+	destroy writer
+
+@Test
 function varUIntContinuationAlphabetHandlesAllFiveBitGroups()
 	for length = 60 to 63
 		let expected = repeated("x", length)

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -266,6 +266,36 @@ function nestedEnvelopesRemainChunkedBeyondOneRuntimeString()
 	destroy original
 
 @Test
+function rawChunkedPayloadCanBeReadWithoutFlattening()
+	let payload = new ChunkedString()
+	payload.append(repeated("a", 180))
+	payload.append(repeated("b", 180))
+	payload.append(repeated("c", 180))
+	payload.append(repeated("d", 180))
+	payload.append(repeated("e", 180))
+	payload.append(repeated("f", 180))
+	let writer = new FieldSerializationWriter(1)
+	writer.writeRaw("custom", "x", payload)
+	let data = writer.finish()
+	let reader = new FieldSerializationReader(data)
+	let decoded = reader.readRawChunked("custom", "x")
+
+	destroy reader
+	destroy data
+	destroy writer
+	destroy payload
+
+	decoded.length().assertEquals(1080)
+	(decoded.getChunkCount() > 1).assertTrue()
+	decoded.getUnsafeSubString(0, 180).assertEquals(repeated("a", 180))
+	decoded.getUnsafeSubString(180, 360).assertEquals(repeated("b", 180))
+	decoded.getUnsafeSubString(360, 540).assertEquals(repeated("c", 180))
+	decoded.getUnsafeSubString(540, 720).assertEquals(repeated("d", 180))
+	decoded.getUnsafeSubString(720, 900).assertEquals(repeated("e", 180))
+	decoded.getUnsafeSubString(900, 1080).assertEquals(repeated("f", 180))
+	destroy decoded
+
+@Test
 function legacySerializableStillRoundTripsItsOriginalFormat()
 	let original = new OldPlayerState()
 	original.score = 11

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -12,6 +12,24 @@ function repeated(string value, int count) returns string
 		result += value
 	return result
 
+tuple InventorySlot(int itemId, int charges)
+
+function FieldSerializationWriter.write(string name, InventorySlot value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	wurstForFields(value, (fieldName, fieldValue) -> child.write(fieldName, fieldValue))
+	this.writeObject(name, child)
+
+function FieldSerializationReader.read(string name, InventorySlot oldValue) returns InventorySlot
+	let child = this.readObject(name)
+	var result = oldValue
+	if child.isValid()
+		wurstMapFields(result, (fieldName, fieldValue) -> fieldValue.readSerializedField(child, fieldName))
+	destroy child
+	return result
+
+function InventorySlot.readSerializedField(FieldSerializationReader reader, string name) returns InventorySlot
+	return reader.read(name, this)
+
 class ChildState implements FieldSerializable
 	use SerializableFields
 
@@ -51,6 +69,11 @@ class LargeParentState implements FieldSerializable
 
 	ondestroy
 		destroy child
+
+class CustomTupleState implements FieldSerializable
+	use SerializableFields
+
+	InventorySlot slot = InventorySlot(0, 0)
 
 class RenameScore implements SerializationMigration
 	override function migrate(FieldSerializationReader reader)
@@ -94,6 +117,21 @@ function reflectedFieldsRoundTripNestedClassesAndTuples()
 	loaded.child.level.assertEquals(8)
 	loaded.child.title.assertEquals("veteran")
 	constructions.assertEquals(2)
+
+	destroy original
+	destroy loaded
+	destroy data
+
+@Test
+function customTupleCodecRoundTripsThroughSerializableFields()
+	let original = new CustomTupleState()
+	original.slot = InventorySlot(1234, 7)
+
+	let data = original.serialize()
+	let loaded = new CustomTupleState().load(data)
+
+	loaded.slot.itemId.assertEquals(1234)
+	loaded.slot.charges.assertEquals(7)
 
 	destroy original
 	destroy loaded

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -1,0 +1,76 @@
+package SerializableTests
+import Serializable
+import ChunkedString
+
+int constructions = 0
+
+class PlayerState
+    use SerializableFields
+
+    int score = 1
+    real ratio = 1.
+    string name = "default"
+    boolean active = false
+
+    construct()
+        constructions++
+
+class OldPlayerState extends Serializable
+    int score = 0
+
+    override function serializeProperties()
+        addProperty("score", score)
+
+    override function deserializeProperties()
+        score = getIntProperty("score")
+
+@Test
+function reflectedFieldsRoundTrip()
+    constructions = 0
+    let original = new PlayerState()
+    original.score = 42
+    original.ratio = 2.5
+    original.name = "Wurst"
+    original.active = true
+
+    let data = original.serialize()
+    let loaded = new PlayerState().load(data)
+
+    loaded.score.assertEquals(42)
+    loaded.ratio.assertEquals(2.5)
+    loaded.name.assertEquals("Wurst")
+    loaded.active.assertTrue()
+    constructions.assertEquals(2)
+
+    destroy original
+    destroy loaded
+    destroy data
+
+@Test
+function reflectedFieldsPreserveDefaultsForMissingData()
+    let oldState = new OldPlayerState()
+    oldState.score = 7
+    let data = oldState.serialize()
+
+    let loaded = new PlayerState()
+    loaded.deserialize(data).assertTrue()
+    loaded.score.assertEquals(7)
+    loaded.ratio.assertEquals(1.)
+    loaded.name.assertEquals("default")
+    loaded.active.assertFalse()
+
+    destroy oldState
+    destroy loaded
+    destroy data
+
+@Test
+function reflectedFieldsRejectInvalidData()
+    let state = new PlayerState()
+    state.score = 9
+    let invalid = new ChunkedString()..append("invalid")
+
+    state.deserialize(invalid).assertFalse()
+    state.score.assertEquals(9)
+
+    destroy state
+    destroy invalid

--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -1,76 +1,188 @@
 package SerializableTests
 import Serializable
+import StructuredSerialization
 import ChunkedString
+import Vectors
 
 int constructions = 0
 
-class PlayerState
-    use SerializableFields
+class ChildState implements FieldSerializable
+	use SerializableFields
 
-    int score = 1
-    real ratio = 1.
-    string name = "default"
-    boolean active = false
+	int level = 1
+	string title = "rookie"
 
-    construct()
-        constructions++
+class PlayerState implements FieldSerializable
+	use SerializableFields
+
+	int score = 1
+	real ratio = 1.
+	string name = "default"
+	boolean active = false
+	vec3 position = vec3(0., 0., 0.)
+	ChildState child = new ChildState()
+
+	construct()
+		constructions++
+
+	ondestroy
+		destroy child
+
+class RenameScore implements SerializationMigration
+	override function migrate(FieldSerializationReader reader)
+		if reader.getSchemaVersion() < 2
+			int defaultPoints = 0
+			int oldPoints = reader.read("points", defaultPoints)
+			reader.renameField("points", "score")
+			reader.set("score", oldPoints + 1)
 
 class OldPlayerState extends Serializable
-    int score = 0
+	int score = 0
 
-    override function serializeProperties()
-        addProperty("score", score)
+	override function serializeProperties()
+		addProperty("score", score)
 
-    override function deserializeProperties()
-        score = getIntProperty("score")
-
-@Test
-function reflectedFieldsRoundTrip()
-    constructions = 0
-    let original = new PlayerState()
-    original.score = 42
-    original.ratio = 2.5
-    original.name = "Wurst"
-    original.active = true
-
-    let data = original.serialize()
-    let loaded = new PlayerState().load(data)
-
-    loaded.score.assertEquals(42)
-    loaded.ratio.assertEquals(2.5)
-    loaded.name.assertEquals("Wurst")
-    loaded.active.assertTrue()
-    constructions.assertEquals(2)
-
-    destroy original
-    destroy loaded
-    destroy data
+	override function deserializeProperties()
+		score = getIntProperty("score")
 
 @Test
-function reflectedFieldsPreserveDefaultsForMissingData()
-    let oldState = new OldPlayerState()
-    oldState.score = 7
-    let data = oldState.serialize()
+function reflectedFieldsRoundTripNestedClassesAndTuples()
+	constructions = 0
+	let original = new PlayerState()
+	original.score = 42
+	original.ratio = 2.5
+	original.name = "Würst|=save"
+	original.active = true
+	original.position = vec3(12.5, -4., 99.)
+	original.child.level = 8
+	original.child.title = "veteran"
 
-    let loaded = new PlayerState()
-    loaded.deserialize(data).assertTrue()
-    loaded.score.assertEquals(7)
-    loaded.ratio.assertEquals(1.)
-    loaded.name.assertEquals("default")
-    loaded.active.assertFalse()
+	let data = original.serialize(3)
+	let loaded = new PlayerState().load(data)
 
-    destroy oldState
-    destroy loaded
-    destroy data
+	loaded.score.assertEquals(42)
+	loaded.ratio.assertEquals(2.5)
+	loaded.name.assertEquals("Würst|=save")
+	loaded.active.assertTrue()
+	loaded.position.x.assertEquals(12.5)
+	loaded.position.y.assertEquals(-4.)
+	loaded.position.z.assertEquals(99.)
+	loaded.child.level.assertEquals(8)
+	loaded.child.title.assertEquals("veteran")
+	constructions.assertEquals(2)
+
+	destroy original
+	destroy loaded
+	destroy data
 
 @Test
-function reflectedFieldsRejectInvalidData()
-    let state = new PlayerState()
-    state.score = 9
-    let invalid = new ChunkedString()..append("invalid")
+function taggedFieldsPreserveDefaultsAndSkipUnknownData()
+	let writer = new FieldSerializationWriter(4)
+	int score = 7
+	writer.write("score", score)
+	writer.writeRaw("futureField", "x", "opaque future data")
+	let data = writer.finish()
+	let loaded = new PlayerState()
 
-    state.deserialize(invalid).assertFalse()
-    state.score.assertEquals(9)
+	loaded.deserialize(data).assertTrue()
+	loaded.score.assertEquals(7)
+	loaded.ratio.assertEquals(1.)
+	loaded.name.assertEquals("default")
+	loaded.active.assertFalse()
+	loaded.child.level.assertEquals(1)
 
-    destroy state
-    destroy invalid
+	destroy writer
+	destroy data
+	destroy loaded
+
+@Test
+function schemaMigrationCanRenameFields()
+	let writer = new FieldSerializationWriter(1)
+	int points = 73
+	writer.write("points", points)
+	let data = writer.finish()
+	let loaded = new PlayerState()
+	let migration = new RenameScore()
+
+	loaded.deserialize(data, SERIALIZATION_INTEGRITY_KEY, migration).assertTrue()
+	loaded.score.assertEquals(74)
+
+	destroy migration
+	destroy loaded
+	destroy data
+	destroy writer
+
+@Test
+function integrityKeyRejectsEditedOrForeignDataWithoutMutation()
+	let writer = new FieldSerializationWriter(1, 12345)
+	int score = 9
+	writer.write("score", score)
+	let data = writer.finish()
+	let state = new PlayerState()
+
+	state.deserialize(data, 54321).assertFalse()
+	state.score.assertEquals(1)
+
+	let encoded = data.getUnsafeString()
+	let edited = new ChunkedString()..append("X" + encoded.substring(1))
+	state.deserialize(edited, 12345).assertFalse()
+	state.score.assertEquals(1)
+
+	destroy edited
+	destroy state
+	destroy data
+	destroy writer
+
+@Test
+function parserRejectsTruncationAndDuplicateFieldIds()
+	let truncated = new ChunkedString()..append("WS20")
+	let truncatedReader = new FieldSerializationReader(truncated)
+	truncatedReader.isValid().assertFalse()
+
+	let writer = new FieldSerializationWriter(1)
+	int first = 1
+	int second = 2
+	writer.write("same", first)
+	writer.write("same", second)
+	let duplicate = writer.finish()
+	let duplicateReader = new FieldSerializationReader(duplicate)
+	duplicateReader.isValid().assertFalse()
+
+	destroy duplicateReader
+	destroy truncatedReader
+	destroy duplicate
+	destroy writer
+	destroy truncated
+
+@Test
+function signedIntegerCodecPreservesFullWidthValues()
+	let writer = new FieldSerializationWriter(1)
+	int minimum = INT_MIN
+	int maximum = INT_MAX
+	writer.write("minimum", minimum)
+	writer.write("maximum", maximum)
+	let data = writer.finish()
+	let reader = new FieldSerializationReader(data)
+	int defaultValue = 0
+
+	reader.isValid().assertTrue()
+	reader.read("minimum", defaultValue).assertEquals(INT_MIN)
+	reader.read("maximum", defaultValue).assertEquals(INT_MAX)
+
+	destroy reader
+	destroy data
+	destroy writer
+
+@Test
+function legacySerializableStillRoundTripsItsOriginalFormat()
+	let original = new OldPlayerState()
+	original.score = 11
+	let data = original.serialize()
+	let loaded = new OldPlayerState()
+	loaded.deserialize(data)
+
+	loaded.score.assertEquals(11)
+
+	destroy loaded
+	destroy data
+	destroy original

--- a/wurst/file/StructuredSerialization.wurst
+++ b/wurst/file/StructuredSerialization.wurst
@@ -8,7 +8,41 @@ import ChunkedString
 function FieldSerializationReader.readTuple(string name) returns FieldSerializationReader
 	return this.readObject(name)
 
-/** Standard tuple codecs. Custom tuples can follow the same pair of writer/reader overloads. */
+/**
+Standard tuple codecs.
+
+Field names passed to these codecs are converted by `FieldSerializationWriter` to fixed-width
+numeric IDs; names are not stored in the save string. Classes and tuples therefore use the same
+wire representation and migration rules. The compiler does not derive persistence IDs from field
+annotations; serialization metadata deliberately remains owned by this library.
+
+Custom tuples need three overloads because tuples cannot implement `FieldSerializable`. The field
+intrinsics keep the codec concise and support mixed component types through overload resolution:
+
+```
+tuple InventorySlot(int itemId, int charges)
+
+public function FieldSerializationWriter.write(string name, InventorySlot value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	wurstForFields(value, (fieldName, fieldValue) -> child.write(fieldName, fieldValue))
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, InventorySlot oldValue) returns InventorySlot
+	let child = this.readObject(name)
+	var result = oldValue
+	if child.isValid()
+		wurstMapFields(result, (fieldName, fieldValue) -> fieldValue.readSerializedField(child, fieldName))
+	destroy child
+	return result
+
+public function InventorySlot.readSerializedField(FieldSerializationReader reader, string name) returns InventorySlot
+	return reader.read(name, this)
+```
+
+Nested custom tuples compose once each tuple type provides these overloads. Keep component names
+stable. For tuple-specific schema changes, increment the child writer's schema version and call
+`child.renameField(oldName, newName)` before `wurstMapFields` when reading older versions.
+*/
 public function FieldSerializationWriter.write(string name, vec2 value)
 	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
 	child.write("x", value.x)

--- a/wurst/file/StructuredSerialization.wurst
+++ b/wurst/file/StructuredSerialization.wurst
@@ -1,0 +1,160 @@
+package StructuredSerialization
+import public StructuredSerializationCore
+import Vectors
+import Angle
+import Colors
+import ChunkedString
+
+function FieldSerializationReader.readTuple(string name) returns FieldSerializationReader
+	return this.readObject(name)
+
+/** Standard tuple codecs. Custom tuples can follow the same pair of writer/reader overloads. */
+public function FieldSerializationWriter.write(string name, vec2 value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("x", value.x)
+	child.write("y", value.y)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, vec2 oldValue) returns vec2
+	let child = this.readTuple(name)
+	let result = child.isValid() ? vec2(child.read("x", oldValue.x), child.read("y", oldValue.y)) : oldValue
+	destroy child
+	return result
+
+public function vec2.readSerializedField(FieldSerializationReader reader, string name) returns vec2
+	return reader.read(name, this)
+
+public function FieldSerializationWriter.write(string name, vec3 value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("x", value.x)
+	child.write("y", value.y)
+	child.write("z", value.z)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, vec3 oldValue) returns vec3
+	let child = this.readTuple(name)
+	let result = child.isValid() ? vec3(child.read("x", oldValue.x), child.read("y", oldValue.y), child.read("z", oldValue.z)) : oldValue
+	destroy child
+	return result
+
+public function vec3.readSerializedField(FieldSerializationReader reader, string name) returns vec3
+	return reader.read(name, this)
+
+public function FieldSerializationWriter.write(string name, angle value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("radians", value.radians)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, angle oldValue) returns angle
+	let child = this.readTuple(name)
+	let result = child.isValid() ? angle(child.read("radians", oldValue.radians)) : oldValue
+	destroy child
+	return result
+
+public function angle.readSerializedField(FieldSerializationReader reader, string name) returns angle
+	return reader.read(name, this)
+
+public function FieldSerializationWriter.write(string name, color value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("red", value.red)
+	child.write("green", value.green)
+	child.write("blue", value.blue)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, color oldValue) returns color
+	let child = this.readTuple(name)
+	let result = child.isValid() ? color(child.read("red", oldValue.red), child.read("green", oldValue.green), child.read("blue", oldValue.blue)) : oldValue
+	destroy child
+	return result
+
+public function color.readSerializedField(FieldSerializationReader reader, string name) returns color
+	return reader.read(name, this)
+
+public function FieldSerializationWriter.write(string name, colorA value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("red", value.red)
+	child.write("green", value.green)
+	child.write("blue", value.blue)
+	child.write("alpha", value.alpha)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, colorA oldValue) returns colorA
+	let child = this.readTuple(name)
+	let result = child.isValid() ? colorA(child.read("red", oldValue.red), child.read("green", oldValue.green), child.read("blue", oldValue.blue), child.read("alpha", oldValue.alpha)) : oldValue
+	destroy child
+	return result
+
+public function colorA.readSerializedField(FieldSerializationReader reader, string name) returns colorA
+	return reader.read(name, this)
+
+public function FieldSerializationWriter.write(string name, colorHSV value)
+	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
+	child.write("h", value.h)
+	child.write("s", value.s)
+	child.write("v", value.v)
+	this.writeObject(name, child)
+
+public function FieldSerializationReader.read(string name, colorHSV oldValue) returns colorHSV
+	let child = this.readTuple(name)
+	let result = child.isValid() ? colorHSV(child.read("h", oldValue.h), child.read("s", oldValue.s), child.read("v", oldValue.v)) : oldValue
+	destroy child
+	return result
+
+public function colorHSV.readSerializedField(FieldSerializationReader reader, string name) returns colorHSV
+	return reader.read(name, this)
+
+/**
+Modern serialization for dedicated state/DAO classes.
+
+Add `implements FieldSerializable` and `use SerializableFields`. The compiler expands field
+iteration to direct accesses. The tagged format tolerates field reordering, added/removed fields,
+and unknown future wire types. Missing fields retain constructor defaults. Use a schema version and
+`SerializationMigration` for semantic changes or `renameField` for renamed attributes.
+*/
+public module SerializableFields
+	function writeSerializedFields(FieldSerializationWriter writer)
+		// Compatibility aliases keep this usable with compilers predating canonical #1224 names.
+		forFields((fieldName, value) -> writer.write(fieldName, value))
+
+	function readSerializedFields(FieldSerializationReader reader)
+		mapFields((fieldName, value) -> value.readSerializedField(reader, fieldName))
+
+	function readSerializedField(FieldSerializationReader reader, string name) returns thistype
+		let child = reader.readObject(name)
+		if child.isValid()
+			readSerializedFields(child)
+		destroy child
+		return this
+
+	function serialize() returns ChunkedString
+		return serialize(1, SERIALIZATION_INTEGRITY_KEY)
+
+	function serialize(int schemaVersion) returns ChunkedString
+		return serialize(schemaVersion, SERIALIZATION_INTEGRITY_KEY)
+
+	function serialize(int schemaVersion, int integrityKey) returns ChunkedString
+		let writer = new FieldSerializationWriter(schemaVersion, integrityKey)
+		writeSerializedFields(writer)
+		let result = writer.finish()
+		destroy writer
+		return result
+
+	function deserialize(ChunkedString input) returns boolean
+		return deserialize(input, SERIALIZATION_INTEGRITY_KEY, null)
+
+	function deserialize(ChunkedString input, int integrityKey) returns boolean
+		return deserialize(input, integrityKey, null)
+
+	function deserialize(ChunkedString input, int integrityKey, SerializationMigration migration) returns boolean
+		let reader = new FieldSerializationReader(input, integrityKey)
+		let result = reader.isValid()
+		if result
+			migration?.migrate(reader)
+			readSerializedFields(reader)
+		destroy reader
+		return result
+
+	/** Loads valid data into this instance and returns it for concise construction and chaining. */
+	function load(ChunkedString input) returns thistype
+		deserialize(input)
+		return this

--- a/wurst/file/StructuredSerialization.wurst
+++ b/wurst/file/StructuredSerialization.wurst
@@ -37,11 +37,24 @@ public function FieldSerializationReader.read(string name, InventorySlot oldValu
 
 public function InventorySlot.readSerializedField(FieldSerializationReader reader, string name) returns InventorySlot
 	return reader.read(name, this)
+
+class InventoryState implements FieldSerializable
+	use FieldSerializableLifecycle
+	InventorySlot slot = InventorySlot(0, 0)
+
+	override function writeSerializedFields(FieldSerializationWriter writer)
+		wurstForFields((fieldName, fieldValue) -> writer.write(fieldName, fieldValue))
+
+	override function readSerializedFields(FieldSerializationReader reader)
+		wurstMapFields((fieldName, fieldValue) -> fieldValue.readSerializedField(reader, fieldName))
 ```
 
-Nested custom tuples compose once each tuple type provides these overloads. Keep component names
-stable. For tuple-specific schema changes, increment the child writer's schema version and call
-`child.renameField(oldName, newName)` before `wurstMapFields` when reading older versions.
+`SerializableFields` can automatically use codecs declared by `StructuredSerialization`. For
+package-local codecs, use `FieldSerializableLifecycle` and keep the two intrinsic mapping methods
+in the same package as the overloads, as above. Nested custom tuples then compose once each tuple
+type provides the three overloads. Keep component names stable. For tuple-specific schema changes,
+increment the child writer's schema version and call `child.renameField(oldName, newName)` before
+`wurstMapFields` when reading older versions.
 */
 public function FieldSerializationWriter.write(string name, vec2 value)
 	let child = new FieldSerializationWriter(1, this.getIntegrityKey())
@@ -138,20 +151,16 @@ public function colorHSV.readSerializedField(FieldSerializationReader reader, st
 	return reader.read(name, this)
 
 /**
-Modern serialization for dedicated state/DAO classes.
+Shared typed lifecycle for `FieldSerializable` classes that provide their own field mapping.
 
-Add `implements FieldSerializable` and `use SerializableFields`. The compiler expands field
-iteration to direct accesses. The tagged format tolerates field reordering, added/removed fields,
-and unknown future wire types. Missing fields retain constructor defaults. Use a schema version and
-`SerializationMigration` for semantic changes or `renameField` for renamed attributes.
+Prefer `SerializableFields` when all field codecs come from `StructuredSerialization`. Use this
+module when mapping fields in the class package is necessary, notably for package-local tuple
+codecs. Implement `writeSerializedFields` and `readSerializedFields`; serialization, integrity,
+migration, nested-object loading, and typed `load` remain provided here.
 */
-public module SerializableFields
-	function writeSerializedFields(FieldSerializationWriter writer)
-		// Compatibility aliases keep this usable with compilers predating canonical #1224 names.
-		forFields((fieldName, value) -> writer.write(fieldName, value))
-
-	function readSerializedFields(FieldSerializationReader reader)
-		mapFields((fieldName, value) -> value.readSerializedField(reader, fieldName))
+public module FieldSerializableLifecycle
+	abstract function writeSerializedFields(FieldSerializationWriter writer)
+	abstract function readSerializedFields(FieldSerializationReader reader)
 
 	function readSerializedField(FieldSerializationReader reader, string name) returns thistype
 		let child = reader.readObject(name)
@@ -192,3 +201,23 @@ public module SerializableFields
 	function load(ChunkedString input) returns thistype
 		deserialize(input)
 		return this
+
+/**
+Modern automatic serialization for dedicated state/DAO classes using built-in codecs.
+
+Add `implements FieldSerializable` and `use SerializableFields`. The compiler expands field
+iteration to direct accesses. The tagged format tolerates field reordering, added/removed fields,
+and unknown future wire types. Missing fields retain constructor defaults. Use a schema version and
+`SerializationMigration` for semantic changes or `renameField` for renamed attributes. For custom
+tuple codecs declared in the consuming package, use `FieldSerializableLifecycle` as documented
+above so overload resolution occurs where those codecs are visible.
+*/
+public module SerializableFields
+	use FieldSerializableLifecycle
+
+	override function writeSerializedFields(FieldSerializationWriter writer)
+		// Compatibility aliases keep this usable with compilers predating canonical #1224 names.
+		forFields((fieldName, value) -> writer.write(fieldName, value))
+
+	override function readSerializedFields(FieldSerializationReader reader)
+		mapFields((fieldName, value) -> value.readSerializedField(reader, fieldName))

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -85,11 +85,13 @@ function encodeVarUInt(int value) returns string
 	return result
 
 function encodeReal(real value) returns string
-	var result = R2SW(value, 1, SERIALIZATION_REAL_DECIMALS)
-	while result.endsWith("0")
-		result = result.substring(0, result.length() - 1)
-	if result.endsWith(".")
-		result = result.substring(0, result.length() - 1)
+	let decimals = max(SERIALIZATION_REAL_DECIMALS, 0)
+	var result = R2SW(value, 1, decimals)
+	if result.indexOf(".") >= 0
+		while result.endsWith("0")
+			result = result.substring(0, result.length() - 1)
+		if result.endsWith(".")
+			result = result.substring(0, result.length() - 1)
 	return result
 
 /** A parsed migration hook. Hooks are invoked but not destroyed by `deserialize`. */
@@ -183,6 +185,10 @@ public class FieldSerializationWriter
 			output.append(encodeFixedInt(hash))
 			finished = true
 		return output
+
+	ondestroy
+		if not finished
+			destroy output
 
 /** Strict cursor which hashes exactly the bytes accepted by the parser. */
 class SerializationCursor

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -22,39 +22,47 @@ constant SERIALIZATION_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmno
 constant SERIALIZATION_INT_WIDTH = 7
 constant SERIALIZATION_HASH_SEED = 0x45D9F3B
 constant SERIALIZATION_HASH_FACTOR = 0x01000193
+constant SERIALIZATION_INNER_DOMAIN = 0x36A5F217
+constant SERIALIZATION_OUTER_DOMAIN = 0x5C4B91E3
+constant SERIALIZATION_FINAL_DOMAIN = 0x27D4EB2D
 
 constant INT_TOKEN = "i"
 constant REAL_TOKEN = "r"
 constant STRING_TOKEN = "s"
 constant BOOLEAN_TOKEN = "b"
 constant OBJECT_TOKEN = "o"
-
-function updateSerializationHash(int current, string fragment) returns int
+function serializationCharacterWidth(string text, int position) returns int
+	var width = 1
+	var character = text.substring(position, position + width)
+	if character.length() > 1
+		return character.length()
+	if character.isMultibytePartial()
+		width = 2
+		character = text.substring(position, position + width)
+		while width < 4 and position + width < text.length() and character.isMultibytePartial()
+			width++
+			character = text.substring(position, position + width)
+	return width
+function hashSerializationCharacters(int current, string text) returns int
 	var result = current
 	var position = 0
-	while position < fragment.length()
-		var width = 1
-		var character = fragment.substring(position, position + width)
-		if character.length() > 1
-			// Some runtimes return the complete multibyte character for a one-byte slice.
-			width = character.length()
-		else if character.isMultibytePartial()
-			// Other runtimes return an invalid lead-byte marker. Widen until it is complete.
-			width = 2
-			character = fragment.substring(position, position + width)
-			while width < 4 and position + width < fragment.length() and character.isMultibytePartial()
-				width++
-				character = fragment.substring(position, position + width)
-
+	while position < text.length()
+		let width = serializationCharacterWidth(text, position)
+		let character = text.substring(position, position + width)
 		result = result.bitXor(character.getHash()) * SERIALIZATION_HASH_FACTOR
 		if character != character.toLowerCase()
 			result = result.bitXor(0x5A)
 		position += width
 	return result
 
+function mixSerializationKey(int value) returns int
+	var result = value
+	result = result.bitXor(result.shiftr(16)) * 0x7FEB352D
+	result = result.bitXor(result.shiftr(15)) * 0x846CA68B
+	return result.bitXor(result.shiftr(16))
 /** Returns the stable, case-sensitive numeric ID used for a persisted field name. */
 public function serializationFieldId(string name) returns int
-	return updateSerializationHash(SERIALIZATION_HASH_SEED, name)
+	return hashSerializationCharacters(SERIALIZATION_HASH_SEED, name)
 
 function encodeFixedInt(int value) returns string
 	var remaining = value
@@ -110,6 +118,45 @@ function copyChunkedString(ChunkedString source) returns ChunkedString
 		result.append(source.getChunk(i))
 	return result
 
+/** Streaming two-stage keyed hash with chunk-independent multibyte handling. */
+class SerializationHasher
+	int key
+	int innerHash
+	string pending = ""
+	boolean finished = false
+
+	construct(int key)
+		this.key = key
+		innerHash = SERIALIZATION_HASH_SEED.bitXor(mixSerializationKey(key.bitXor(SERIALIZATION_INNER_DOMAIN)))
+
+	private function appendBlock(string block)
+		let combined = pending + block
+		var position = 0
+		while combined.length() - position > 4
+			let width = serializationCharacterWidth(combined, position)
+			let character = combined.substring(position, position + width)
+			innerHash = hashSerializationCharacters(innerHash, character)
+			position += width
+		pending = combined.substring(position)
+
+	function append(string fragment)
+		var position = 0
+		while position < fragment.length()
+			let blockLength = min(128, fragment.length() - position)
+			appendBlock(fragment.substring(position, position + blockLength))
+			position += blockLength
+
+	function finish() returns int
+		if not finished
+			innerHash = hashSerializationCharacters(innerHash, pending)
+			pending = ""
+			finished = true
+
+		let outerKey = mixSerializationKey(key.bitXor(SERIALIZATION_OUTER_DOMAIN))
+		var outerHash = SERIALIZATION_HASH_SEED.bitXor(outerKey)
+		outerHash = hashSerializationCharacters(outerHash, encodeFixedInt(innerHash))
+		outerHash = outerHash.bitXor(mixSerializationKey(key.bitXor(SERIALIZATION_FINAL_DOMAIN)))
+		return mixSerializationKey(outerHash)
 /** A parsed migration hook. Hooks are invoked but not destroyed by `deserialize`. */
 public interface SerializationMigration
 	function migrate(FieldSerializationReader reader)
@@ -124,7 +171,7 @@ public interface FieldSerializable
 public class FieldSerializationWriter
 	private let output = new ChunkedString()
 	private int integrityKey
-	private int hash
+	private SerializationHasher hasher
 	private boolean finished = false
 
 	construct(int schemaVersion)
@@ -132,13 +179,13 @@ public class FieldSerializationWriter
 
 	construct(int schemaVersion, int integrityKey)
 		this.integrityKey = integrityKey
-		hash = SERIALIZATION_HASH_SEED.bitXor(integrityKey)
+		hasher = new SerializationHasher(integrityKey)
 		appendHashed(SERIALIZATION_MAGIC)
 		appendHashed(encodeVarUInt(schemaVersion))
 
 	private function appendHashed(string fragment)
 		output.append(fragment)
-		hash = updateSerializationHash(hash, fragment)
+		hasher.append(fragment)
 
 	private function appendHashed(ChunkedString fragments)
 		for i = 0 to fragments.getChunkCount() - 1
@@ -198,11 +245,12 @@ public class FieldSerializationWriter
 	/** Completes the envelope. The returned value belongs to the caller. */
 	function finish() returns ChunkedString
 		if not finished
-			output.append(encodeFixedInt(hash))
+			output.append(encodeFixedInt(hasher.finish()))
 			finished = true
 		return output
 
 	ondestroy
+		destroy hasher
 		if not finished
 			destroy output
 
@@ -211,13 +259,13 @@ class SerializationCursor
 	ChunkedString input
 	int pointer = 0
 	int bodyEnd = 0
-	int hash
+	SerializationHasher hasher
 	boolean valid = true
 
 	construct(ChunkedString input, int integrityKey)
 		this.input = input
 		bodyEnd = input.length() - SERIALIZATION_INT_WIDTH
-		hash = SERIALIZATION_HASH_SEED.bitXor(integrityKey)
+		hasher = new SerializationHasher(integrityKey)
 		if bodyEnd < SERIALIZATION_MAGIC.length()
 			valid = false
 
@@ -227,7 +275,7 @@ class SerializationCursor
 			return ""
 		let result = input.getUnsafeSubString(pointer, pointer + length)
 		pointer += length
-		hash = updateSerializationHash(hash, result)
+		hasher.append(result)
 		return result
 
 	/** Reads a range by source chunks, without materializing it as one runtime string. */
@@ -246,7 +294,7 @@ class SerializationCursor
 			if chunkEnd > start and chunkStart < rangeEnd
 				let fragment = chunk.substring(max(start - chunkStart, 0), min(rangeEnd - chunkStart, chunk.length()))
 				result.append(fragment)
-				hash = updateSerializationHash(hash, fragment)
+				hasher.append(fragment)
 			chunkStart = chunkEnd
 			if chunkStart >= rangeEnd
 				break
@@ -277,6 +325,9 @@ class SerializationCursor
 			place *= 32
 		valid = false
 		return -1
+
+	ondestroy
+		destroy hasher
 
 /** Parsed field table. Unknown fields and wire tokens are retained and safely skippable. */
 public class FieldSerializationReader
@@ -316,7 +367,7 @@ public class FieldSerializationReader
 
 		if cursor.valid and cursor.pointer == cursor.bodyEnd
 			let expected = input.getUnsafeSubString(cursor.bodyEnd, input.length())
-			valid = isFixedInt(expected) and decodeFixedInt(expected) == cursor.hash
+			valid = isFixedInt(expected) and decodeFixedInt(expected) == cursor.hasher.finish()
 		destroy cursor
 
 	function isValid() returns boolean

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -29,22 +29,32 @@ constant STRING_TOKEN = "s"
 constant BOOLEAN_TOKEN = "b"
 constant OBJECT_TOKEN = "o"
 
-/** Returns the stable, case-sensitive numeric ID used for a persisted field name. */
-public function serializationFieldId(string name) returns int
-	var result = SERIALIZATION_HASH_SEED
-	for character in name
-		result = result.bitXor(character.getHash()) * SERIALIZATION_HASH_FACTOR
-		if character != character.toLowerCase()
-			result = result.bitXor(0x5A)
-	return result
-
 function updateSerializationHash(int current, string fragment) returns int
 	var result = current
-	for character in fragment
+	var position = 0
+	while position < fragment.length()
+		var width = 1
+		var character = fragment.substring(position, position + width)
+		if character.length() > 1
+			// Some runtimes return the complete multibyte character for a one-byte slice.
+			width = character.length()
+		else if character.isMultibytePartial()
+			// Other runtimes return an invalid lead-byte marker. Widen until it is complete.
+			width = 2
+			character = fragment.substring(position, position + width)
+			while width < 4 and position + width < fragment.length() and character.isMultibytePartial()
+				width++
+				character = fragment.substring(position, position + width)
+
 		result = result.bitXor(character.getHash()) * SERIALIZATION_HASH_FACTOR
 		if character != character.toLowerCase()
 			result = result.bitXor(0x5A)
+		position += width
 	return result
+
+/** Returns the stable, case-sensitive numeric ID used for a persisted field name. */
+public function serializationFieldId(string name) returns int
+	return updateSerializationHash(SERIALIZATION_HASH_SEED, name)
 
 function encodeFixedInt(int value) returns string
 	var remaining = value

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -1,0 +1,372 @@
+package StructuredSerializationCore
+import ChunkedString
+import HashMap
+import ErrorHandling
+import Bitwise
+
+/** Current tagged serialization wire format. */
+public constant SERIALIZATION_FORMAT_VERSION = 2
+
+/**
+Default integrity key for structured saves. Override this in map configuration with a private,
+map-specific value. It is intended to deter edited player save codes, not provide cryptographic
+authentication against somebody who can inspect the map script.
+*/
+@configurable public constant SERIALIZATION_INTEGRITY_KEY = 0x6D2B79F5
+
+/** Decimal places retained for Jass `real` values. Trailing zeroes are removed on the wire. */
+@configurable public constant SERIALIZATION_REAL_DECIMALS = 6
+
+constant SERIALIZATION_MAGIC = "WS2"
+constant SERIALIZATION_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmnopqrstuvwxyz-_"
+constant SERIALIZATION_INT_WIDTH = 7
+constant SERIALIZATION_HASH_SEED = 0x45D9F3B
+constant SERIALIZATION_HASH_FACTOR = 0x01000193
+
+constant INT_TOKEN = "i"
+constant REAL_TOKEN = "r"
+constant STRING_TOKEN = "s"
+constant BOOLEAN_TOKEN = "b"
+constant OBJECT_TOKEN = "o"
+
+/** Returns the stable, case-sensitive numeric ID used for a persisted field name. */
+public function serializationFieldId(string name) returns int
+	var result = SERIALIZATION_HASH_SEED
+	for character in name
+		result = result.bitXor(character.getHash()) * SERIALIZATION_HASH_FACTOR
+		if character != character.toLowerCase()
+			result = result.bitXor(0x5A)
+	return result
+
+function updateSerializationHash(int current, string fragment) returns int
+	var result = current
+	for character in fragment
+		result = result.bitXor(character.getHash()) * SERIALIZATION_HASH_FACTOR
+		if character != character.toLowerCase()
+			result = result.bitXor(0x5A)
+	return result
+
+function encodeFixedInt(int value) returns string
+	var remaining = value
+	var result = ""
+	for _i = 0 to SERIALIZATION_INT_WIDTH - 1
+		result += SERIALIZATION_DIGITS.substring(remaining.bitAnd(31), remaining.bitAnd(31) + 1)
+		remaining = remaining.shiftr(5)
+	return result
+
+function decodeFixedInt(string encoded) returns int
+	var result = 0
+	for i = 0 to SERIALIZATION_INT_WIDTH - 1
+		let digit = SERIALIZATION_DIGITS.indexOf(encoded.substring(i, i + 1))
+		result = result.bitOr(digit.shiftl(i * 5))
+	return result
+
+function isFixedInt(string encoded) returns boolean
+	if encoded.length() != SERIALIZATION_INT_WIDTH
+		return false
+	for i = 0 to SERIALIZATION_INT_WIDTH - 1
+		let digit = SERIALIZATION_DIGITS.indexOf(encoded.substring(i, i + 1))
+		if digit < 0 or digit >= 32 or (i == SERIALIZATION_INT_WIDTH - 1 and digit > 3)
+			return false
+	return true
+
+function encodeVarUInt(int value) returns string
+	if value < 0
+		error("Cannot encode a negative serialization length or version: " + value)
+		return ""
+
+	var remaining = value
+	var result = ""
+	while remaining >= 32
+		let digit = remaining mod 32 + 32
+		result += SERIALIZATION_DIGITS.substring(digit, digit + 1)
+		remaining = remaining div 32
+	result += SERIALIZATION_DIGITS.substring(remaining, remaining + 1)
+	return result
+
+function encodeReal(real value) returns string
+	var result = R2SW(value, 1, SERIALIZATION_REAL_DECIMALS)
+	while result.endsWith("0")
+		result = result.substring(0, result.length() - 1)
+	if result.endsWith(".")
+		result = result.substring(0, result.length() - 1)
+	return result
+
+/** A parsed migration hook. Hooks are invoked but not destroyed by `deserialize`. */
+public interface SerializationMigration
+	function migrate(FieldSerializationReader reader)
+
+/** Opt-in contract used for recursively serialized class fields. */
+public interface FieldSerializable
+	function writeSerializedFields(FieldSerializationWriter writer)
+	function readSerializedFields(FieldSerializationReader reader)
+	function readSerializedField(FieldSerializationReader reader, string name) returns thistype
+
+/** Builds one compact, versioned structured-save envelope. */
+public class FieldSerializationWriter
+	private let output = new ChunkedString()
+	private int integrityKey
+	private int hash
+	private boolean finished = false
+
+	construct(int schemaVersion)
+		this(schemaVersion, SERIALIZATION_INTEGRITY_KEY)
+
+	construct(int schemaVersion, int integrityKey)
+		this.integrityKey = integrityKey
+		hash = SERIALIZATION_HASH_SEED.bitXor(integrityKey)
+		appendHashed(SERIALIZATION_MAGIC)
+		appendHashed(encodeVarUInt(schemaVersion))
+
+	private function appendHashed(string fragment)
+		output.append(fragment)
+		hash = updateSerializationHash(hash, fragment)
+
+	/** Writes a future-compatible raw field. Custom token values should be one ASCII byte. */
+	function writeRaw(string name, string token, string payload)
+		if finished
+			error("Cannot add fields after FieldSerializationWriter.finish().")
+			return
+		if token.length() != 1
+			error("Serialization wire tokens must be exactly one byte.")
+			return
+
+		appendHashed(encodeFixedInt(serializationFieldId(name)))
+		appendHashed(token)
+		appendHashed(encodeVarUInt(payload.length()))
+		appendHashed(payload)
+
+	function write(string name, int value)
+		writeRaw(name, INT_TOKEN, encodeFixedInt(value))
+
+	function write(string name, real value)
+		writeRaw(name, REAL_TOKEN, encodeReal(value))
+
+	function write(string name, string value)
+		writeRaw(name, STRING_TOKEN, value)
+
+	function write(string name, boolean value)
+		writeRaw(name, BOOLEAN_TOKEN, value ? "1" : "0")
+
+	function getIntegrityKey() returns int
+		return integrityKey
+
+	/** Recursively writes an opted-in non-null class instance. */
+	function write(string name, FieldSerializable value)
+		let child = new FieldSerializationWriter(1, integrityKey)
+		value.writeSerializedFields(child)
+		writeObject(name, child)
+
+	/** Writes and consumes a child writer as a nested class or tuple envelope. */
+	function writeObject(string name, FieldSerializationWriter child)
+		let childData = child.finish()
+		writeRaw(name, OBJECT_TOKEN, childData.getUnsafeString())
+		destroy childData
+		destroy child
+
+	/** Completes the envelope. The returned value belongs to the caller. */
+	function finish() returns ChunkedString
+		if not finished
+			output.append(encodeFixedInt(hash))
+			finished = true
+		return output
+
+/** Strict cursor which hashes exactly the bytes accepted by the parser. */
+class SerializationCursor
+	ChunkedString input
+	int pointer = 0
+	int bodyEnd = 0
+	int hash
+	boolean valid = true
+
+	construct(ChunkedString input, int integrityKey)
+		this.input = input
+		bodyEnd = input.length() - SERIALIZATION_INT_WIDTH
+		hash = SERIALIZATION_HASH_SEED.bitXor(integrityKey)
+		if bodyEnd < SERIALIZATION_MAGIC.length()
+			valid = false
+
+	function read(int length) returns string
+		if not valid or length < 0 or pointer + length > bodyEnd
+			valid = false
+			return ""
+		let result = input.getUnsafeSubString(pointer, pointer + length)
+		pointer += length
+		hash = updateSerializationHash(hash, result)
+		return result
+
+	function readVarUInt() returns int
+		var result = 0
+		var place = 1
+		var digits = 0
+		while valid and digits < 7
+			let encoded = read(1)
+			let index = SERIALIZATION_DIGITS.indexOf(encoded)
+			if index < 0
+				valid = false
+				return -1
+			let digit = index mod 32
+			if digit > (INT_MAX - result) div place
+				valid = false
+				return -1
+			result += digit * place
+			digits++
+			if index < 32
+				return result
+			if place > INT_MAX div 32
+				valid = false
+				return -1
+			place *= 32
+		valid = false
+		return -1
+
+/** Parsed field table. Unknown fields and wire tokens are retained and safely skippable. */
+public class FieldSerializationReader
+	private let tokenMap = new HashMap<int, string>()
+	private let payloadMap = new HashMap<int, string>()
+	private int schemaVersion = 0
+	private int integrityKey
+	private boolean valid = false
+
+	construct()
+
+	construct(ChunkedString input)
+		this(input, SERIALIZATION_INTEGRITY_KEY)
+
+	construct(ChunkedString input, int integrityKey)
+		this.integrityKey = integrityKey
+		let cursor = new SerializationCursor(input, integrityKey)
+		if cursor.read(SERIALIZATION_MAGIC.length()) != SERIALIZATION_MAGIC
+			cursor.valid = false
+		schemaVersion = cursor.readVarUInt()
+
+		while cursor.valid and cursor.pointer < cursor.bodyEnd
+			let encodedId = cursor.read(SERIALIZATION_INT_WIDTH)
+			if not isFixedInt(encodedId)
+				cursor.valid = false
+			else
+				let fieldId = decodeFixedInt(encodedId)
+				let token = cursor.read(1)
+				let length = cursor.readVarUInt()
+				let payload = cursor.read(length)
+				if token.length() != 1 or tokenMap.has(fieldId)
+					cursor.valid = false
+				else
+					tokenMap.put(fieldId, token)
+					payloadMap.put(fieldId, payload)
+
+		if cursor.valid and cursor.pointer == cursor.bodyEnd
+			let expected = input.getUnsafeSubString(cursor.bodyEnd, input.length())
+			valid = isFixedInt(expected) and decodeFixedInt(expected) == cursor.hash
+		destroy cursor
+
+	function isValid() returns boolean
+		return valid
+
+	function getSchemaVersion() returns int
+		return schemaVersion
+
+	function getIntegrityKey() returns int
+		return integrityKey
+
+	function hasField(string name) returns boolean
+		return valid and payloadMap.has(serializationFieldId(name))
+
+	function hasRaw(string name, string token) returns boolean
+		let fieldId = serializationFieldId(name)
+		return valid and tokenMap.has(fieldId) and tokenMap.get(fieldId) == token
+
+	function readRaw(string name, string token, string oldValue) returns string
+		let fieldId = serializationFieldId(name)
+		return valid and tokenMap.has(fieldId) and tokenMap.get(fieldId) == token ? payloadMap.get(fieldId) : oldValue
+
+	function read(string name, int oldValue) returns int
+		let payload = readRaw(name, INT_TOKEN, "")
+		return isFixedInt(payload) ? decodeFixedInt(payload) : oldValue
+
+	function read(string name, real oldValue) returns real
+		let payload = readRaw(name, REAL_TOKEN, "")
+		return payload == "" ? oldValue : payload.toReal()
+
+	function read(string name, string oldValue) returns string
+		return readRaw(name, STRING_TOKEN, oldValue)
+
+	function read(string name, boolean oldValue) returns boolean
+		let payload = readRaw(name, BOOLEAN_TOKEN, "")
+		return payload == "0" ? false : (payload == "1" ? true : oldValue)
+
+	/** Replaces or creates a decoded field during migration. */
+	function setRaw(string name, string token, string payload)
+		if not valid or token.length() != 1
+			return
+		let fieldId = serializationFieldId(name)
+		tokenMap.put(fieldId, token)
+		payloadMap.put(fieldId, payload)
+
+	function set(string name, int value)
+		setRaw(name, INT_TOKEN, encodeFixedInt(value))
+
+	function set(string name, real value)
+		setRaw(name, REAL_TOKEN, encodeReal(value))
+
+	function set(string name, string value)
+		setRaw(name, STRING_TOKEN, value)
+
+	function set(string name, boolean value)
+		setRaw(name, BOOLEAN_TOKEN, value ? "1" : "0")
+
+	function removeField(string name)
+		let fieldId = serializationFieldId(name)
+		tokenMap.remove(fieldId)
+		payloadMap.remove(fieldId)
+
+	/** Mutates an existing opted-in child object when a valid nested envelope is present. */
+	function readInto(string name, FieldSerializable oldValue) returns boolean
+		let child = readObject(name)
+		let result = child.isValid()
+		if result
+			oldValue.readSerializedFields(child)
+		destroy child
+		return result
+
+	/** Returns the nested reader for an object/tuple field, or an invalid reader when absent. */
+	function readObject(string name) returns FieldSerializationReader
+		let payload = readRaw(name, OBJECT_TOKEN, "")
+		if payload == ""
+			return new FieldSerializationReader()
+		let childData = new ChunkedString()..append(payload)
+		let child = new FieldSerializationReader(childData, integrityKey)
+		destroy childData
+		return child
+
+	/**
+	Moves a persisted value from an old field name to a new one. Call this from a migration before
+	field mapping. Existing data under the new name wins, making repeated migrations idempotent.
+	*/
+	function renameField(string oldName, string newName)
+		let oldId = serializationFieldId(oldName)
+		let newId = serializationFieldId(newName)
+		if oldId == newId
+			return
+		if tokenMap.has(oldId) and not tokenMap.has(newId)
+			tokenMap.put(newId, tokenMap.get(oldId))
+			payloadMap.put(newId, payloadMap.get(oldId))
+		tokenMap.remove(oldId)
+		payloadMap.remove(oldId)
+
+	ondestroy
+		destroy tokenMap
+		destroy payloadMap
+
+/** Type-directed field readers used by the compiler-expanded mapper. */
+public function int.readSerializedField(FieldSerializationReader reader, string name) returns int
+	return reader.read(name, this)
+
+public function real.readSerializedField(FieldSerializationReader reader, string name) returns real
+	return reader.read(name, this)
+
+public function string.readSerializedField(FieldSerializationReader reader, string name) returns string
+	return reader.read(name, this)
+
+public function boolean.readSerializedField(FieldSerializationReader reader, string name) returns boolean
+	return reader.read(name, this)

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -94,6 +94,12 @@ function encodeReal(real value) returns string
 			result = result.substring(0, result.length() - 1)
 	return result
 
+function copyChunkedString(ChunkedString source) returns ChunkedString
+	let result = new ChunkedString(source.getChunkSize())
+	for i = 0 to source.getChunkCount() - 1
+		result.append(source.getChunk(i))
+	return result
+
 /** A parsed migration hook. Hooks are invoked but not destroyed by `deserialize`. */
 public interface SerializationMigration
 	function migrate(FieldSerializationReader reader)
@@ -322,6 +328,16 @@ public class FieldSerializationReader
 	function readRaw(string name, string token, string oldValue) returns string
 		let fieldId = serializationFieldId(name)
 		return valid and tokenMap.has(fieldId) and tokenMap.get(fieldId) == token ? payloadMap.get(fieldId).getUnsafeString() : oldValue
+
+	/**
+	Returns an independent chunked copy of a raw payload, or `null` when the field/token is absent.
+	The caller owns and must destroy the returned value.
+	*/
+	function readRawChunked(string name, string token) returns ChunkedString
+		let fieldId = serializationFieldId(name)
+		if not valid or not tokenMap.has(fieldId) or tokenMap.get(fieldId) != token
+			return null
+		return copyChunkedString(payloadMap.get(fieldId))
 
 	function read(string name, int oldValue) returns int
 		let payload = readRaw(name, INT_TOKEN, "")

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -18,7 +18,7 @@ authentication against somebody who can inspect the map script.
 @configurable public constant SERIALIZATION_REAL_DECIMALS = 6
 
 constant SERIALIZATION_MAGIC = "WS2"
-constant SERIALIZATION_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmnopqrstuvwxyz-_"
+constant SERIALIZATION_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmnopqrstuvwxyz-_!~*+"
 constant SERIALIZATION_INT_WIDTH = 7
 constant SERIALIZATION_HASH_SEED = 0x45D9F3B
 constant SERIALIZATION_HASH_FACTOR = 0x01000193
@@ -122,19 +122,32 @@ public class FieldSerializationWriter
 		output.append(fragment)
 		hash = updateSerializationHash(hash, fragment)
 
-	/** Writes a future-compatible raw field. Custom token values should be one ASCII byte. */
-	function writeRaw(string name, string token, string payload)
+	private function appendHashed(ChunkedString fragments)
+		for i = 0 to fragments.getChunkCount() - 1
+			appendHashed(fragments.getChunk(i))
+
+	private function beginRaw(string name, string token, int payloadLength) returns boolean
 		if finished
 			error("Cannot add fields after FieldSerializationWriter.finish().")
-			return
+			return false
 		if token.length() != 1
 			error("Serialization wire tokens must be exactly one byte.")
-			return
+			return false
 
 		appendHashed(encodeFixedInt(serializationFieldId(name)))
 		appendHashed(token)
-		appendHashed(encodeVarUInt(payload.length()))
-		appendHashed(payload)
+		appendHashed(encodeVarUInt(payloadLength))
+		return true
+
+	/** Writes a future-compatible raw field. Custom token values should be one ASCII byte. */
+	function writeRaw(string name, string token, string payload)
+		if beginRaw(name, token, payload.length())
+			appendHashed(payload)
+
+	/** Writes a raw field without flattening its chunked payload. The caller retains ownership. */
+	function writeRaw(string name, string token, ChunkedString payload)
+		if beginRaw(name, token, payload.length())
+			appendHashed(payload)
 
 	function write(string name, int value)
 		writeRaw(name, INT_TOKEN, encodeFixedInt(value))
@@ -160,7 +173,7 @@ public class FieldSerializationWriter
 	/** Writes and consumes a child writer as a nested class or tuple envelope. */
 	function writeObject(string name, FieldSerializationWriter child)
 		let childData = child.finish()
-		writeRaw(name, OBJECT_TOKEN, childData.getUnsafeString())
+		writeRaw(name, OBJECT_TOKEN, childData)
 		destroy childData
 		destroy child
 
@@ -187,12 +200,35 @@ class SerializationCursor
 			valid = false
 
 	function read(int length) returns string
-		if not valid or length < 0 or pointer + length > bodyEnd
+		if not valid or length < 0 or length > bodyEnd - pointer
 			valid = false
 			return ""
 		let result = input.getUnsafeSubString(pointer, pointer + length)
 		pointer += length
 		hash = updateSerializationHash(hash, result)
+		return result
+
+	/** Reads a range by source chunks, without materializing it as one runtime string. */
+	function readChunked(int length) returns ChunkedString
+		let result = new ChunkedString()
+		if not valid or length < 0 or length > bodyEnd - pointer
+			valid = false
+			return result
+
+		let start = pointer
+		let rangeEnd = pointer + length
+		var chunkStart = 0
+		for i = 0 to input.getChunkCount() - 1
+			let chunk = input.getChunk(i)
+			let chunkEnd = chunkStart + chunk.length()
+			if chunkEnd > start and chunkStart < rangeEnd
+				let fragment = chunk.substring(max(start - chunkStart, 0), min(rangeEnd - chunkStart, chunk.length()))
+				result.append(fragment)
+				hash = updateSerializationHash(hash, fragment)
+			chunkStart = chunkEnd
+			if chunkStart >= rangeEnd
+				break
+		pointer = rangeEnd
 		return result
 
 	function readVarUInt() returns int
@@ -223,7 +259,7 @@ class SerializationCursor
 /** Parsed field table. Unknown fields and wire tokens are retained and safely skippable. */
 public class FieldSerializationReader
 	private let tokenMap = new HashMap<int, string>()
-	private let payloadMap = new HashMap<int, string>()
+	private let payloadMap = new IterableMap<int, ChunkedString>()
 	private int schemaVersion = 0
 	private int integrityKey
 	private boolean valid = false
@@ -248,9 +284,10 @@ public class FieldSerializationReader
 				let fieldId = decodeFixedInt(encodedId)
 				let token = cursor.read(1)
 				let length = cursor.readVarUInt()
-				let payload = cursor.read(length)
+				let payload = cursor.readChunked(length)
 				if token.length() != 1 or tokenMap.has(fieldId)
 					cursor.valid = false
+					destroy payload
 				else
 					tokenMap.put(fieldId, token)
 					payloadMap.put(fieldId, payload)
@@ -278,7 +315,7 @@ public class FieldSerializationReader
 
 	function readRaw(string name, string token, string oldValue) returns string
 		let fieldId = serializationFieldId(name)
-		return valid and tokenMap.has(fieldId) and tokenMap.get(fieldId) == token ? payloadMap.get(fieldId) : oldValue
+		return valid and tokenMap.has(fieldId) and tokenMap.get(fieldId) == token ? payloadMap.get(fieldId).getUnsafeString() : oldValue
 
 	function read(string name, int oldValue) returns int
 		let payload = readRaw(name, INT_TOKEN, "")
@@ -300,8 +337,10 @@ public class FieldSerializationReader
 		if not valid or token.length() != 1
 			return
 		let fieldId = serializationFieldId(name)
+		if payloadMap.has(fieldId)
+			destroy payloadMap.get(fieldId)
 		tokenMap.put(fieldId, token)
-		payloadMap.put(fieldId, payload)
+		payloadMap.put(fieldId, new ChunkedString()..append(payload))
 
 	function set(string name, int value)
 		setRaw(name, INT_TOKEN, encodeFixedInt(value))
@@ -317,6 +356,8 @@ public class FieldSerializationReader
 
 	function removeField(string name)
 		let fieldId = serializationFieldId(name)
+		if payloadMap.has(fieldId)
+			destroy payloadMap.get(fieldId)
 		tokenMap.remove(fieldId)
 		payloadMap.remove(fieldId)
 
@@ -329,15 +370,12 @@ public class FieldSerializationReader
 		destroy child
 		return result
 
-	/** Returns the nested reader for an object/tuple field, or an invalid reader when absent. */
+	/** Returns a nested reader borrowed from this reader, or an invalid reader when absent. */
 	function readObject(string name) returns FieldSerializationReader
-		let payload = readRaw(name, OBJECT_TOKEN, "")
-		if payload == ""
+		let fieldId = serializationFieldId(name)
+		if not valid or not tokenMap.has(fieldId) or tokenMap.get(fieldId) != OBJECT_TOKEN
 			return new FieldSerializationReader()
-		let childData = new ChunkedString()..append(payload)
-		let child = new FieldSerializationReader(childData, integrityKey)
-		destroy childData
-		return child
+		return new FieldSerializationReader(payloadMap.get(fieldId), integrityKey)
 
 	/**
 	Moves a persisted value from an old field name to a new one. Call this from a migration before
@@ -351,10 +389,14 @@ public class FieldSerializationReader
 		if tokenMap.has(oldId) and not tokenMap.has(newId)
 			tokenMap.put(newId, tokenMap.get(oldId))
 			payloadMap.put(newId, payloadMap.get(oldId))
+		else if payloadMap.has(oldId)
+			destroy payloadMap.get(oldId)
 		tokenMap.remove(oldId)
 		payloadMap.remove(oldId)
 
 	ondestroy
+		for fieldId in payloadMap
+			destroy payloadMap.get(fieldId)
 		destroy tokenMap
 		destroy payloadMap
 


### PR DESCRIPTION
## Summary

- add real IDE-visible declarations for the canonical `wurstForFields`, `wurstMapFields`, and `wurstNewInstance<T>()` compiler intrinsics from WurstScript #1224
- add an opt-in `StructuredSerialization` package; the existing `Serializable` API and wire format remain unchanged
- introduce a compact tagged format with stable numeric field IDs, length-delimited records, schema versions, unknown-field skipping, and constructor-default preservation
- protect saves by default with a configurable keyed rolling integrity hash intended to deter player-edited save codes
- provide migration hooks that can rename, remove, or transform decoded fields before assignment
- compose primitive fields, initialized nested `FieldSerializable` classes, and standard `vec2`, `vec3`, `angle`, `color`, `colorA`, and `colorHSV` tuples
- retain extensible raw reader/writer APIs for application-specific codecs and future wire tokens

## Usage

```wurst
import StructuredSerialization

class PlayerState implements FieldSerializable
    use SerializableFields

    int score = 0
    vec3 position = vec3(0., 0., 0.)
    ChildState child = new ChildState()

let encoded = state.serialize(2)
let loaded = new PlayerState().load(encoded)
```

For renamed or semantically changed fields, pass a `SerializationMigration` to `deserialize`. Maps should override `SERIALIZATION_INTEGRITY_KEY` with their own value. This is deliberate cheat deterrence rather than cryptographic secrecy against someone who can inspect the map script.

The modern API is separate by design: old `Serializable` subclasses continue to read and write the exact legacy format.

## Compiler boundary

The installed compiler used for validation still predates WurstScript #1224: direct calls to the canonical declarations execute their fallback bodies. `SerializableFields` therefore uses the retained compatibility aliases for now. Once #1224 is installed, switching those two calls to the canonical names is a small follow-up.

Automatic construction of nullable nested class fields and fully generic collection/enum codecs still need additional compiler support. Initialized nested classes and the standard tuple codecs work now.

## Validation

- `grill typecheck --quiet`
- `grill test SerializableTests --quiet`
- `grill test --quiet`
- `git diff --check`

Tests cover nested classes, tuples, Unicode/delimiter strings, missing defaults, unknown fields/tokens, migration rename and transformation, foreign-key/tamper rejection, malformed/truncated/duplicate records, full-width signed integers, and legacy-format compatibility.
