### PR TITLE
Deprecate legacy serialization entrypoints

### DIFF
--- a/wurst/file/Serializable.wurst
+++ b/wurst/file/Serializable.wurst
@@ -151,6 +151,7 @@ public abstract class Serializable
     function getStringProperty(string name) returns string
         return stringMap.get(name.getHash())
 
+    @deprecated("Use FieldSerializable with SerializableFields from StructuredSerialization for new save formats.")
     function serialize() returns ChunkedString
         hash = 0
         serOutput = new ChunkedString()
@@ -167,6 +168,7 @@ public abstract class Serializable
             hashStr = "0" + hashStr
         return hashStr
 
+    @deprecated("Use FieldSerializable with SerializableFields from StructuredSerialization for new save formats.")
     function deserialize(ChunkedString input)
         hash = 0
         intMap = new HashMap<int, int>()

--- a/wurst/file/StructuredSerializationCore.wurst
+++ b/wurst/file/StructuredSerializationCore.wurst
@@ -18,6 +18,15 @@ authentication against somebody who can inspect the map script.
 @configurable public constant SERIALIZATION_REAL_DECIMALS = 6
 
 constant SERIALIZATION_MAGIC = "WS2"
+/**
+Wire alphabet shared by fixed integers and variable-length unsigned integers.
+
+This is deliberately not RFC Base64: values 0..31 terminate a varint and values 32..63 carry its
+continuation bit. This keeps common lengths and schema versions to one character, while string
+payloads remain raw instead of paying Base64's size expansion. The strict parser also rejects
+invalid digits before applying data; the general-purpose `Base64` decoder has different semantics.
+Changing this alphabet or its ordering would break existing structured saves.
+*/
 constant SERIALIZATION_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmnopqrstuvwxyz-_!~*+"
 constant SERIALIZATION_INT_WIDTH = 7
 constant SERIALIZATION_HASH_SEED = 0x45D9F3B


### PR DESCRIPTION
## Summary
- deprecate the legacy Serializable serialize/deserialize entrypoints with a migration hint
- document why structured serialization uses a strict varint wire alphabet instead of the general-purpose Base64 codec

## Verification
- grill typecheck
- grill test --quiet
- git diff --check