### PR TITLE
Add mapping-only structured serialization module

### DIFF
--- a/wurst/file/SerializableTests.wurst
+++ b/wurst/file/SerializableTests.wurst
@@ -98,6 +98,20 @@ class OldPlayerState extends Serializable
 	override function deserializeProperties()
 		score = getIntProperty("score")
 
+class TransitionalPlayerState extends Serializable implements FieldSerializable
+	use SerializableFieldMapping
+
+	int score = 0
+	string title = "default"
+
+	override function serializeProperties()
+		addProperty("score", score)
+		addProperty("title", title)
+
+	override function deserializeProperties()
+		score = getIntProperty("score")
+		title = getStringProperty("title")
+
 @Test
 function reflectedFieldsRoundTripNestedClassesAndTuples()
 	constructions = 0
@@ -127,6 +141,27 @@ function reflectedFieldsRoundTripNestedClassesAndTuples()
 	destroy original
 	destroy loaded
 	destroy data
+
+@Test
+function mappingOnlyModuleCoexistsWithLegacySerializable()
+	let original = new TransitionalPlayerState()
+	original.score = 81
+	original.title = "transition"
+	let writer = new FieldSerializationWriter(1)
+	writer.write("profile", original)
+	let data = writer.finish()
+	let reader = new FieldSerializationReader(data)
+	let loaded = new TransitionalPlayerState()
+
+	reader.readInto("profile", loaded).assertTrue()
+	loaded.score.assertEquals(81)
+	loaded.title.assertEquals("transition")
+
+	destroy loaded
+	destroy reader
+	destroy data
+	destroy writer
+	destroy original
 
 @Test
 function customTupleCodecRoundTripsThroughSerializableFields()

--- a/wurst/file/StructuredSerialization.wurst
+++ b/wurst/file/StructuredSerialization.wurst
@@ -203,6 +203,28 @@ public module FieldSerializableLifecycle
 		return this
 
 /**
+Automatic field mapping without adding a second `serialize`/`deserialize` lifecycle.
+
+Use this during a compatibility window when a data class still extends legacy `Serializable`, or
+when another base class already owns lifecycle methods. The class must implement `FieldSerializable`.
+All of its accessible mutable instance fields participate; keep runtime-only state in a separate
+class because persisted-field annotation filtering is not available.
+*/
+public module SerializableFieldMapping
+	function writeSerializedFields(FieldSerializationWriter writer)
+		wurstForFields((fieldName, value) -> writer.write(fieldName, value))
+
+	function readSerializedFields(FieldSerializationReader reader)
+		wurstMapFields((fieldName, value) -> value.readSerializedField(reader, fieldName))
+
+	function readSerializedField(FieldSerializationReader reader, string name) returns thistype
+		let child = reader.readObject(name)
+		if child.isValid()
+			readSerializedFields(child)
+		destroy child
+		return this
+
+/**
 Modern automatic serialization for dedicated state/DAO classes using built-in codecs.
 
 Add `implements FieldSerializable` and `use SerializableFields`. The compiler expands field
@@ -210,7 +232,8 @@ iteration to direct accesses. The tagged format tolerates field reordering, adde
 and unknown future wire types. Missing fields retain constructor defaults. Use a schema version and
 `SerializationMigration` for semantic changes or `renameField` for renamed attributes. For custom
 tuple codecs declared in the consuming package, use `FieldSerializableLifecycle` as documented
-above so overload resolution occurs where those codecs are visible.
+above so overload resolution occurs where those codecs are visible. Classes that must also retain
+legacy `Serializable` should use `SerializableFieldMapping` to avoid conflicting lifecycle methods.
 */
 public module SerializableFields
 	use FieldSerializableLifecycle


### PR DESCRIPTION
## Summary
- add SerializableFieldMapping for compiler-mapped DAO fields without adding a competing serialize/deserialize lifecycle
- support classes that temporarily retain legacy Serializable during backwards-compatible migrations
- document that field-level persistence annotations are not available and runtime-only state belongs in a separate DAO
- add a focused transition-class roundtrip test

## Verification
- grill typecheck --quiet
- grill test SerializableTests --quiet
- grill test --quiet