### PR TITLE
Query every benchmark point once instead of nine times

### DIFF
--- a/wurst/math/PolygonTests.wurst
+++ b/wurst/math/PolygonTests.wurst
@@ -179,12 +179,17 @@ function benchmarkPoint(int index) returns vec2
 	(polygon.classify(vec2(96, 96)) == polygon.classifyLinear(vec2(96, 96))).assertTrue()
 	destroy polygon
 
-@Test function acceleratedClassificationMatchesLinearFor10000Points()
+/** Every point benchmarkPoint can produce, which is fewer than it looks.
+	Both strides are coprime to 1152, so the sequence has period 1152 and an index past that
+	repeats a point already queried. Ten thousand iterations asked the same 1152 questions
+	nearly nine times over, for no coverage and enough interpreted work to reach the
+	twenty second test budget on a loaded machine. */
+@Test function acceleratedClassificationMatchesLinearForEveryBenchmarkPoint()
 	let polygon = benchmarkPolygon()
 	var totalCandidates = 0
 	var linearEdges = 0
 	var mixedQueries = 0
-	for i = 0 to 9999
+	for i = 0 to 1151
 		let point = benchmarkPoint(i)
 		(polygon.classify(point) == polygon.classifyLinear(point)).assertTrue()
 		if point.x >= 0 and point.x <= 1024 and point.y >= 0 and point.y <= 1024
@@ -195,7 +200,7 @@ function benchmarkPoint(int index) returns vec2
 			mixedQueries++
 		totalCandidates += candidates
 	totalCandidates.assertLessThan(linearEdges)
-	print("Polygon 10000-lookups: mixed=" + mixedQueries +
+	print("Polygon 1152-lookups: mixed=" + mixedQueries +
 		", linearEdges=" + linearEdges + ", candidateEdges=" + totalCandidates)
 	destroy polygon
 


### PR DESCRIPTION
`acceleratedClassificationMatchesLinearFor10000Points` fails as a timeout - "did not complete in 20 seconds, it might contain an endless loop" - and the ten thousand iterations are why.

`benchmarkPoint` is:

```wurst
function benchmarkPoint(int index) returns vec2
	return vec2(((index * 73) mod 1152 - 64).toReal(), ((index * 151) mod 1152 - 64).toReal())
```

Both strides are coprime to 1152, so each coordinate cycles through every residue and the pair has period 1152. Index 1152 is index 0 again. Iterating to 9999 asked the same 1152 questions nearly nine times over, which bought no coverage and cost enough interpreted work - 64 vertices scanned linearly per point, plus the accelerated query - to reach the test budget.

One full period queries every point the helper can produce, so coverage is identical and the test is roughly nine times cheaper. Both aggregate assertions compare totals which scale with the iteration count (`totalCandidates < linearEdges`), so they hold unchanged. Renamed to say what it covers rather than a number which was never the point.

Verified through the compiler's stdlib suite: the test times out reliably before and the suite passes 460/460 after.