### PR TITLE
Add a hash map which keeps its keys as they are

### DIFF
--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -2,39 +2,6 @@ package FastHashMap
 import NoWurst
 import Wurst
 
-/**	A hash map which keeps its keys as they are.
-
-	`HashMap` casts every key to an int and stores it in a `Table`, which works for
-	handles and for anything castable but loses the type on the way in: two keys which
-	cast to the same int collide, and a key which is not castable cannot be used at all.
-	This map takes a bound on its key type instead, so hashing and comparing are done by
-	the key's own implementation and the key is stored as itself.
-
-	The bound is `Hashable`, which asks for a hash and an equality:
-
-		implements Hashable<vec2>
-			function hash(vec2 v) returns int
-				return v.x.toInt() * 31 + v.y.toInt()
-			function equals(vec2 a, vec2 b) returns boolean
-				return a == b
-
-		let seen = new FastHashMap<vec2, unit>()
-		seen.put(caster.getPos(), caster)
-
-	Instances for `int` and `string` come with this package. Declare one beside your own
-	type to use it as a key.
-
-	Storage is one array per specialisation, carved into a section per instance, the way
-	`ArrayList` works. A section is `CAPACITY` slots and does not grow, so a map which
-	fills up refuses further keys rather than rehashing - see `isFull`. Raise
-	`FastHashMap_CAPACITY` in your build config if you need larger maps; every map of one
-	key and value type pays that size.
-
-	Collisions are handled by linear probing inside the section. A removed slot becomes a
-	tombstone rather than empty, so a probe which passed over it still finds keys put down
-	beyond it.
-*/
-
 /**	What a key type has to provide to be used in a `FastHashMap`. */
 public interface Hashable<T:>
 	/**	Any int; keys which are equal must hash alike, or a lookup will miss them. */
@@ -63,6 +30,42 @@ implements Hashable<string>
 
 constant SLOTS = FASTHASHMAP_CAPACITY * FASTHASHMAP_MAX_INSTANCES
 
+/**	A hash map which keeps its keys as they are.
+
+	`HashMap` casts every key to an int and stores it in a `Table`, which works for
+	handles and for anything castable but loses the type on the way in: two keys which
+	cast to the same int collide, and a key which is not castable cannot be used at all.
+	This map takes a bound on its key type instead, so hashing and comparing are done by
+	the key's own implementation and the key is stored as itself.
+
+	The bound is `Hashable`, which asks for a hash and an equality:
+
+		implements Hashable<vec2>
+			function hash(vec2 v) returns int
+				return v.x.toInt() * 31 + v.y.toInt()
+			function equals(vec2 a, vec2 b) returns boolean
+				return a == b
+
+		let seen = new FastHashMap<vec2, unit>()
+		seen.put(caster.getPos(), caster)
+
+	Instances for `int` and `string` come with this package. Declare one beside your own
+	type to use it as a key.
+
+	Storage is one array per specialisation, carved into a section per instance, the way
+	`ArrayList` works. A section is `FASTHASHMAP_CAPACITY` slots and does not grow, so a map
+	which fills up refuses further keys rather than rehashing - see `isFull`. That and
+	`FASTHASHMAP_MAX_INSTANCES` are both configurable, and every map of one key and value
+	type pays the section size.
+
+	On the Jass target their product is bounded by `JASS_MAX_ARRAY_SIZE` as well, the storage
+	being one fixed-size array: a construction which would hand out slots past its end errors
+	instead. Lua grows the table, so only the section count applies there.
+
+	Collisions are handled by linear probing inside the section. A removed slot becomes a
+	tombstone rather than empty, so a probe which passed over it still finds keys put down
+	beyond it.
+*/
 public class FastHashMap<K: Hashable, V:>
 	private static K array keys
 	private static V array values
@@ -82,6 +85,12 @@ public class FastHashMap<K: Hashable, V:>
 	construct()
 		if nextFree + FASTHASHMAP_CAPACITY > SLOTS
 			error("FastHashMap: out of sections. Raise FASTHASHMAP_MAX_INSTANCES.")
+			base = -1
+		else if not isLua and nextFree + FASTHASHMAP_CAPACITY > JASS_MAX_ARRAY_SIZE
+			// One fixed-size array per specialisation on this target, so a section reaching past
+			// its end would read and write slots outside it. Lua grows the table instead.
+			error("FastHashMap: storage limit exceeded for this key and value type. "
+				+ "FASTHASHMAP_CAPACITY * FASTHASHMAP_MAX_INSTANCES must fit JASS_MAX_ARRAY_SIZE.")
 			base = -1
 		else
 			base = nextFree
@@ -149,6 +158,12 @@ public class FastHashMap<K: Hashable, V:>
 			return false
 		used[s] = false
 		dead[s] = true
+		// The slot still holds the key and value it had, which on Lua is a reference this map no
+		// longer owns. A tombstone is never read for either, so releasing them is safe; on Jass
+		// the arrays hold values and this is a no-op.
+		if isLua
+			keys[s] = null
+			values[s] = null
 		count--
 		return true
 
@@ -172,4 +187,8 @@ public class FastHashMap<K: Hashable, V:>
 		for i = 0 to FASTHASHMAP_CAPACITY - 1
 			used[base + i] = false
 			dead[base + i] = false
+			// as in remove: the slot's contents are no longer the map's to hold on to
+			if isLua
+				keys[base + i] = null
+				values[base + i] = null
 		count = 0

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -1,0 +1,175 @@
+package FastHashMap
+import NoWurst
+import Wurst
+
+/**	A hash map which keeps its keys as they are.
+
+	`HashMap` casts every key to an int and stores it in a `Table`, which works for
+	handles and for anything castable but loses the type on the way in: two keys which
+	cast to the same int collide, and a key which is not castable cannot be used at all.
+	This map takes a bound on its key type instead, so hashing and comparing are done by
+	the key's own implementation and the key is stored as itself.
+
+	The bound is `Hashable`, which asks for a hash and an equality:
+
+		implements Hashable<vec2>
+			function hash(vec2 v) returns int
+				return v.x.toInt() * 31 + v.y.toInt()
+			function equals(vec2 a, vec2 b) returns boolean
+				return a == b
+
+		let seen = new FastHashMap<vec2, unit>()
+		seen.put(caster.getPos(), caster)
+
+	Instances for `int` and `string` come with this package. Declare one beside your own
+	type to use it as a key.
+
+	Storage is one array per specialisation, carved into a section per instance, the way
+	`ArrayList` works. A section is `CAPACITY` slots and does not grow, so a map which
+	fills up refuses further keys rather than rehashing - see `isFull`. Raise
+	`FastHashMap_CAPACITY` in your build config if you need larger maps; every map of one
+	key and value type pays that size.
+
+	Collisions are handled by linear probing inside the section. A removed slot becomes a
+	tombstone rather than empty, so a probe which passed over it still finds keys put down
+	beyond it.
+*/
+
+/**	What a key type has to provide to be used in a `FastHashMap`. */
+public interface Hashable<T:>
+	/**	Any int; keys which are equal must hash alike, or a lookup will miss them. */
+	function hash(T x) returns int
+	function equals(T a, T b) returns boolean
+
+implements Hashable<int>
+	function hash(int x) returns int
+		return x
+	function equals(int a, int b) returns boolean
+		return a == b
+
+implements Hashable<string>
+	function hash(string x) returns int
+		return x.getHash()
+	function equals(string a, string b) returns boolean
+		return a == b
+
+/**	Slots per map. Fixed at compile time: every map of one key and value type is this
+	size, so raising it costs memory across all of them. */
+@configurable public constant FASTHASHMAP_CAPACITY = 32
+
+/**	The number of maps of one key and value type which can exist. Sections are handed out
+	and never reclaimed, so this is a total over the run rather than a live count. */
+@configurable public constant FASTHASHMAP_MAX_INSTANCES = 256
+
+constant SLOTS = FASTHASHMAP_CAPACITY * FASTHASHMAP_MAX_INSTANCES
+
+public class FastHashMap<K: Hashable, V:>
+	private static K array keys
+	private static V array values
+	private static boolean array used
+	/**	A removed slot cannot go back to empty: a probe which stopped there would miss keys
+		put down beyond it. It becomes a tombstone instead - passed over when searching,
+		reused when putting. */
+	private static boolean array dead
+	/**	Never written, so a read yields V's default. That is the only way to say "no value"
+		for a type parameter, and it costs an array read rather than a branch. */
+	private static V array none
+	private static int nextFree = 0
+
+	private int base
+	private int count = 0
+
+	construct()
+		if nextFree + FASTHASHMAP_CAPACITY > SLOTS
+			error("FastHashMap: out of sections. Raise FASTHASHMAP_MAX_INSTANCES.")
+			base = -1
+		else
+			base = nextFree
+			nextFree += FASTHASHMAP_CAPACITY
+
+	/**	The slot holding key, or the one it belongs in: the first tombstone passed over,
+		else the empty slot the probe stopped at. Capacity is fixed, so a full table
+		returns -1 rather than probing forever. */
+	private function slotFor(K key) returns int
+		var i = K.hash(key) mod FASTHASHMAP_CAPACITY
+		if i < 0
+			i += FASTHASHMAP_CAPACITY
+		var firstDead = -1
+		var probes = 0
+		while probes < FASTHASHMAP_CAPACITY
+			let s = base + i
+			if used[s] and K.equals(keys[s], key)
+				return s
+			if not used[s] and not dead[s]
+				if firstDead >= 0
+					return firstDead
+				return s
+			if dead[s] and firstDead < 0
+				firstDead = s
+			i = (i + 1) mod FASTHASHMAP_CAPACITY
+			probes++
+		return firstDead
+
+	/**	Stores value under key, replacing what was there. A full map keeps what it has. */
+	function put(K key, V value)
+		if base < 0
+			return
+		let s = slotFor(key)
+		if s < base
+			return
+		if not used[s]
+			used[s] = true
+			dead[s] = false
+			keys[s] = key
+			count++
+		values[s] = value
+
+	/**	The value stored under key, or V's default when there is none. */
+	function get(K key) returns V
+		if base < 0
+			return none[0]
+		let s = slotFor(key)
+		if s < base or not used[s]
+			return none[0]
+		return values[s]
+
+	/**	Whether a value is stored under key. */
+	function has(K key) returns boolean
+		if base < 0
+			return false
+		let s = slotFor(key)
+		return s >= base and used[s]
+
+	/**	Removes key, returning whether it was there. */
+	function remove(K key) returns boolean
+		if base < 0
+			return false
+		let s = slotFor(key)
+		if s < base or not used[s]
+			return false
+		used[s] = false
+		dead[s] = true
+		count--
+		return true
+
+	/**	How many keys are stored. */
+	function size() returns int
+		return count
+
+	/**	Whether the map is empty. */
+	function isEmpty() returns boolean
+		return count == 0
+
+	/**	Whether a further key would be refused. A map at capacity accepts writes to keys it
+		already holds, and refuses new ones. */
+	function isFull() returns boolean
+		return count >= FASTHASHMAP_CAPACITY
+
+	/**	Forgets every key, leaving the section reusable by this map. */
+	function clear()
+		if base < 0
+			return
+		for i = 0 to FASTHASHMAP_CAPACITY - 1
+			used[base + i] = false
+			dead[base + i] = false
+		count = 0

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -163,12 +163,18 @@ public class FastHashMap<K: Hashable, V:>
 			probes++
 		return firstDead
 
-	/**	Stores value under key, replacing what was there. A full map keeps what it has. */
+	/**	Stores value under key, replacing what was there.
+		<p>
+		A key the map already holds is always writable. A new key needs a slot, and a section does not
+		grow, so a full map reports rather than dropping the write: silently losing a store is close to
+		impossible to find from the outside, and `isFull` is there to ask beforehand. */
 	function put(K key, V value)
 		if base < 0
 			return
 		let s = slotFor(key)
 		if s < base
+			error("FastHashMap: full, so the key was not stored. Ask isFull() first, or raise "
+				+ "FASTHASHMAP_CAPACITY.")
 			return
 		if not used[s]
 			used[s] = true
@@ -237,6 +243,39 @@ public class FastHashMap<K: Hashable, V:>
 			freeSection[freeSectionCount] = base
 			freeSectionCount++
 			base = -1
+
+	/**	The first occupied slot at or after `startSlot`, or -1 when there is none. Pass 0 to begin.
+		<p>
+		Walking slots rather than handing out an iterator or taking a closure: it allocates nothing,
+		which is what a map iterating every frame needs, and it avoids dispatching a bound through a
+		closure, which is not supported on every target. A `for in` wrapper can be built on this.
+
+			var s = map.nextEntry(0)
+			while s >= 0
+				doSomething(map.keyAt(s), map.valueAt(s))
+				s = map.nextEntry(s + 1)
+	*/
+	function nextEntry(int startSlot) returns int
+		if base < 0
+			return -1
+		for i = startSlot to FASTHASHMAP_CAPACITY - 1
+			if i >= 0 and used[base + i]
+				return i
+		return -1
+
+	/**	The key in a slot `nextEntry` returned. Reading any other slot is meaningless. */
+	function keyAt(int slot) returns K
+		if base < 0 or slot < 0 or slot >= FASTHASHMAP_CAPACITY or not used[base + slot]
+			error("FastHashMap: keyAt on a slot which holds nothing; use the value nextEntry returned.")
+			return keys[base]
+		return keys[base + slot]
+
+	/**	The value in a slot `nextEntry` returned. */
+	function valueAt(int slot) returns V
+		if base < 0 or slot < 0 or slot >= FASTHASHMAP_CAPACITY or not used[base + slot]
+			error("FastHashMap: valueAt on a slot which holds nothing; use the value nextEntry returned.")
+			return none[0]
+		return values[base + slot]
 
 	/**	Forgets every key, leaving the section reusable by this map. */
 	function clear()

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -113,12 +113,21 @@ public class FastHashMap<K: Hashable, V:>
 		for a type parameter, and it costs an array read rather than a branch. */
 	private static V array none
 	private static int nextFree = 0
+	/**	Sections handed back by destroyed maps, reused before nextFree grows. Every section is the
+		same width, so this is a stack rather than the capacity-matched free list ArrayList keeps:
+		any released section fits any new map. */
+	private static int array freeSection
+	private static int freeSectionCount = 0
 
 	private int base
 	private int count = 0
 
 	construct()
-		if nextFree + FASTHASHMAP_CAPACITY > SLOTS
+		if freeSectionCount > 0
+			// A released section was emptied on the way out, so it is ready to use as it is.
+			freeSectionCount--
+			base = freeSection[freeSectionCount]
+		else if nextFree + FASTHASHMAP_CAPACITY > SLOTS
 			error("FastHashMap: out of sections. Raise FASTHASHMAP_MAX_INSTANCES.")
 			base = -1
 		else if not isLua and nextFree + FASTHASHMAP_CAPACITY > JASS_MAX_ARRAY_SIZE
@@ -214,6 +223,20 @@ public class FastHashMap<K: Hashable, V:>
 		already holds, and refuses new ones. */
 	function isFull() returns boolean
 		return count >= FASTHASHMAP_CAPACITY
+
+	// Releases the section for the next map. Without this, nextFree only ever grew and
+	// FASTHASHMAP_MAX_INSTANCES was a total over the run rather than a count of live maps - so a map
+	// built per spell cast or per unit exhausted the sections and every later one refused its keys.
+	// Emptied on the way out rather than on the way in, so the next map gets a clean section without
+	// paying for it, and so nothing keeps a reference the map no longer owns.
+	ondestroy
+		// Skipped when construction failed to get a section, there being nothing to hand back.
+		if base >= 0
+			clear()
+			// A section is only ever released once, so this cannot outrun the section count itself.
+			freeSection[freeSectionCount] = base
+			freeSectionCount++
+			base = -1
 
 	/**	Forgets every key, leaving the section reusable by this map. */
 	function clear()

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -1,6 +1,7 @@
 package FastHashMap
 import NoWurst
 import Wurst
+import ErrorHandling
 
 /**	What a key type has to provide to be used in a `FastHashMap`. */
 public interface Hashable<T:>

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -2,7 +2,6 @@ package FastHashMap
 import NoWurst
 import Wurst
 import ErrorHandling
-import StringUtils
 
 /**	What a key type has to provide to be used in a `FastHashMap`. */
 public interface Hashable<T:>
@@ -15,9 +14,11 @@ public interface Hashable<T:>
 	between them - harmless in itself, since nothing stores a hash, but it would also mean the
 	interpreter could not stand in for the game while testing distribution. */
 constant HASH_MODULUS = 1000003
-/**	Odd, coprime to the modulus, and large enough that one character's contribution reaches the
-	high bits before the next is added. */
-constant HASH_FACTOR = 31
+/**	Coprime to the modulus, so length and case spread across it rather than landing on a few
+	residues. Kept small enough that `length * HASH_LENGTH_FACTOR` cannot leave the range even for
+	an implausibly long key. */
+constant HASH_LENGTH_FACTOR = 7919
+constant HASH_CASE_FACTOR = 104729
 
 implements Hashable<int>
 	/**	Mixed rather than returned as itself. A slot is chosen by `hash mod FASTHASHMAP_CAPACITY`,
@@ -34,23 +35,36 @@ implements Hashable<int>
 		return a == b
 
 implements Hashable<string>
-	/**	Computed here rather than taken from `StringHash`, which cannot be used for this: it is case
-		insensitive, so `alpha` and `ALPHA` would share a slot, and it collapses every partial
-		multibyte slice to one constant. Both are survivable - `equals` still separates the keys -
-		but a section is `FASTHASHMAP_CAPACITY` slots wide and fills up, so a hash which collides
-		on ordinary keys makes the map refuse them.
+	/**	One pass over the string is done by `StringHash` itself, and the two things it gets wrong are
+		corrected with whole-string work rather than per-character work.
 
-		Position and length are both mixed in, so `ab` and `ba` differ and neither matches `a`.
+		The obvious hash - decode each byte and mix it - costs about two native calls and three string
+		comparisons per character, since `charAt` is a `SubString` and `StringUtils.char` is two
+		comparisons, a `StringHash` and a round trip through the code table. That is forty native calls
+		for a twenty character key against one for `StringHash`, which is not a trade a container called
+		fast should make on every lookup.
 
-		Single bytes are still decoded through `StringUtils.char`, which recovers case where
-		`StringHash` loses it, and which the library already relies on throughout. Non-latin text is
-		the remaining weakness: a lead byte does not decode, so such keys collide with each other and
-		fall back on `equals`. */
+		So `StringHash` does the bytes, and its two defects are patched at fixed cost:
+
+		- It is case insensitive, so `alpha` and `ALPHA` reach here identical. Two comparisons over the
+		  whole string separate the cases which occur in practice - all lower, all upper, mixed. Two
+		  different mixed-case spellings of one word still collide, and probing separates them.
+		- It collapses every partial multibyte slice to one constant, so non-latin keys share a raw
+		  hash. Length is mixed in, which separates those of different length; same-length non-latin
+		  keys still collide and fall back on `equals`.
+
+		The result is order sensitive, because `StringHash` is, and length sensitive. */
 	function hash(string x) returns int
-		var h = x.length() mod HASH_MODULUS
-		for i = 0 to x.length() - 1
-			h = (h * HASH_FACTOR + char(x.charAt(i)).toInt()) mod HASH_MODULUS
-		return h
+		var caseClass = 0
+		if x == x.toLowerCase()
+			caseClass = 1
+		else if x == x.toUpperCase()
+			caseClass = 2
+		// Every term is reduced before being combined, so the sum stays well inside a 32 bit int
+		// however long the key is - see HASH_MODULUS.
+		let raw = x.getHash() mod HASH_MODULUS
+		let length = x.length() mod HASH_MODULUS
+		return (raw + length * HASH_LENGTH_FACTOR + caseClass * HASH_CASE_FACTOR) mod HASH_MODULUS
 
 	function equals(string a, string b) returns boolean
 		return a == b

--- a/wurst/data/FastHashMap.wurst
+++ b/wurst/data/FastHashMap.wurst
@@ -2,6 +2,7 @@ package FastHashMap
 import NoWurst
 import Wurst
 import ErrorHandling
+import StringUtils
 
 /**	What a key type has to provide to be used in a `FastHashMap`. */
 public interface Hashable<T:>
@@ -9,15 +10,48 @@ public interface Hashable<T:>
 	function hash(T x) returns int
 	function equals(T a, T b) returns boolean
 
+/**	Keeps every intermediate below 2^31 so the arithmetic never overflows, on either target.
+	Jass wraps at 32 bits and Lua does not, so a hash which relied on overflow would differ
+	between them - harmless in itself, since nothing stores a hash, but it would also mean the
+	interpreter could not stand in for the game while testing distribution. */
+constant HASH_MODULUS = 1000003
+/**	Odd, coprime to the modulus, and large enough that one character's contribution reaches the
+	high bits before the next is added. */
+constant HASH_FACTOR = 31
+
 implements Hashable<int>
+	/**	Mixed rather than returned as itself. A slot is chosen by `hash mod FASTHASHMAP_CAPACITY`,
+		so identity sends every multiple of the capacity to slot zero - and keys strided by a power
+		of two are the common case, being ids, handles and loop counters. Split into halves so the
+		multiplications stay in range. */
 	function hash(int x) returns int
-		return x
+		let unsigned = x < 0 ? -(x + 1) : x
+		let low = unsigned mod 65536
+		let high = unsigned div 65536
+		return (low * 7919 + high * 6151 + (x < 0 ? 1 : 0)) mod HASH_MODULUS
+
 	function equals(int a, int b) returns boolean
 		return a == b
 
 implements Hashable<string>
+	/**	Computed here rather than taken from `StringHash`, which cannot be used for this: it is case
+		insensitive, so `alpha` and `ALPHA` would share a slot, and it collapses every partial
+		multibyte slice to one constant. Both are survivable - `equals` still separates the keys -
+		but a section is `FASTHASHMAP_CAPACITY` slots wide and fills up, so a hash which collides
+		on ordinary keys makes the map refuse them.
+
+		Position and length are both mixed in, so `ab` and `ba` differ and neither matches `a`.
+
+		Single bytes are still decoded through `StringUtils.char`, which recovers case where
+		`StringHash` loses it, and which the library already relies on throughout. Non-latin text is
+		the remaining weakness: a lead byte does not decode, so such keys collide with each other and
+		fall back on `equals`. */
 	function hash(string x) returns int
-		return x.getHash()
+		var h = x.length() mod HASH_MODULUS
+		for i = 0 to x.length() - 1
+			h = (h * HASH_FACTOR + char(x.charAt(i)).toInt()) mod HASH_MODULUS
+		return h
+
 	function equals(string a, string b) returns boolean
 		return a == b
 

--- a/wurst/data/FastHashMapTests.wurst
+++ b/wurst/data/FastHashMapTests.wurst
@@ -1,0 +1,134 @@
+package FastHashMapTests
+import FastHashMap
+
+@Test
+function testPutGet()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 10)
+	map.put(2, 20)
+	map.get(1).assertEquals(10)
+	map.get(2).assertEquals(20)
+
+@Test
+function testHas()
+	let map = new FastHashMap<int, int>()
+	map.has(5).assertEquals(false)
+	map.put(5, 1)
+	map.has(5).assertEquals(true)
+
+/** A missing key reads as the value type's default rather than as an error. */
+@Test
+function testMissingKeyIsDefault()
+	let map = new FastHashMap<int, int>()
+	map.get(7).assertEquals(0)
+	let strings = new FastHashMap<int, string>()
+	strings.get(7).assertEquals(null)
+
+@Test
+function testPutReplaces()
+	let map = new FastHashMap<int, int>()
+	map.put(3, 30)
+	map.put(3, 31)
+	map.get(3).assertEquals(31)
+	map.size().assertEquals(1)
+
+/** Keys 1 and 1 + CAPACITY land in the same slot, so the probe path is taken. */
+@Test
+function testCollidingKeys()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 10)
+	map.put(1 + FASTHASHMAP_CAPACITY, 90)
+	map.get(1).assertEquals(10)
+	map.get(1 + FASTHASHMAP_CAPACITY).assertEquals(90)
+	map.size().assertEquals(2)
+
+/** A removed slot has to stay passable, or a key probed past it goes missing. */
+@Test
+function testRemoveKeepsLaterKeysReachable()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 10)
+	map.put(1 + FASTHASHMAP_CAPACITY, 90)
+	map.remove(1).assertEquals(true)
+	map.has(1).assertEquals(false)
+	map.get(1 + FASTHASHMAP_CAPACITY).assertEquals(90)
+	map.size().assertEquals(1)
+
+@Test
+function testRemoveMissingKey()
+	let map = new FastHashMap<int, int>()
+	map.remove(4).assertEquals(false)
+	map.size().assertEquals(0)
+
+/** A tombstone is reused rather than left as a hole. */
+@Test
+function testTombstoneIsReused()
+	let map = new FastHashMap<int, int>()
+	map.put(2, 20)
+	map.remove(2)
+	map.put(2, 21)
+	map.get(2).assertEquals(21)
+	map.size().assertEquals(1)
+
+@Test
+function testSizeAndEmpty()
+	let map = new FastHashMap<int, int>()
+	map.isEmpty().assertEquals(true)
+	map.put(1, 1)
+	map.isEmpty().assertEquals(false)
+	map.size().assertEquals(1)
+
+@Test
+function testClear()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 1)
+	map.put(2, 2)
+	map.clear()
+	map.size().assertEquals(0)
+	map.has(1).assertEquals(false)
+	map.put(1, 5)
+	map.get(1).assertEquals(5)
+
+/** A full map keeps what it has and refuses new keys rather than overwriting. */
+@Test
+function testFullMapRefusesNewKeys()
+	let map = new FastHashMap<int, int>()
+	for i = 0 to FASTHASHMAP_CAPACITY - 1
+		map.put(i, i)
+	map.isFull().assertEquals(true)
+	map.size().assertEquals(FASTHASHMAP_CAPACITY)
+	map.put(FASTHASHMAP_CAPACITY + 1000, 1)
+	map.size().assertEquals(FASTHASHMAP_CAPACITY)
+	map.get(0).assertEquals(0)
+	// a key it already holds is still writable
+	map.put(0, 99)
+	map.get(0).assertEquals(99)
+
+/** Two maps of the same types hold separate sections. */
+@Test
+function testInstancesAreIndependent()
+	let a = new FastHashMap<int, int>()
+	let b = new FastHashMap<int, int>()
+	a.put(1, 10)
+	b.put(1, 20)
+	a.get(1).assertEquals(10)
+	b.get(1).assertEquals(20)
+
+/** The string instance comes with the package. */
+@Test
+function testStringKeys()
+	let map = new FastHashMap<string, int>()
+	map.put("alpha", 1)
+	map.put("beta", 2)
+	map.get("alpha").assertEquals(1)
+	map.get("beta").assertEquals(2)
+	map.has("gamma").assertEquals(false)
+
+/** Each key type takes its own instance, so one map class serves several. */
+@Test
+function testTwoSpecialisationsCoexist()
+	let ints = new FastHashMap<int, string>()
+	let strings = new FastHashMap<string, string>()
+	ints.put(1, "one")
+	strings.put("one", "uno")
+	ints.get(1).assertEquals("one")
+	strings.get("one").assertEquals("uno")

--- a/wurst/data/FastHashMapTests.wurst
+++ b/wurst/data/FastHashMapTests.wurst
@@ -132,3 +132,78 @@ function testTwoSpecialisationsCoexist()
 	strings.put("one", "uno")
 	ints.get(1).assertEquals("one")
 	strings.get("one").assertEquals("uno")
+
+/**	Case must survive hashing. `StringHash` is case insensitive, so a hash taken from it sent
+	`alpha` and `ALPHA` to one slot and left them to be separated by probing. */
+@Test function testStringKeysAreCaseSensitive()
+	let map = new FastHashMap<string, int>()
+	map.put("alpha", 1)
+	map.put("ALPHA", 2)
+	map.get("alpha").assertEquals(1)
+	map.get("ALPHA").assertEquals(2)
+	map.size().assertEquals(2)
+
+/**	Position and length are mixed in, so an anagram and a prefix are not the same key. */
+@Test function testStringHashDistinguishesOrderAndLength()
+	let map = new FastHashMap<string, int>()
+	map.put("ab", 1)
+	map.put("ba", 2)
+	map.put("a", 3)
+	map.get("ab").assertEquals(1)
+	map.get("ba").assertEquals(2)
+	map.get("a").assertEquals(3)
+	map.size().assertEquals(3)
+
+/**	Keys strided by the capacity are the case an identity hash got wrong: every one of them
+	lands in slot zero, so a map with room for thirty two of them filled up after a handful of
+	probes. Ids, handles and loop counters all arrive strided like this. */
+@Test function testIntKeysStridedByCapacityDoNotAllCollide()
+	let map = new FastHashMap<int, int>()
+	for i = 0 to 15
+		map.put(i * FASTHASHMAP_CAPACITY, i)
+	map.size().assertEquals(16)
+	for i = 0 to 15
+		map.get(i * FASTHASHMAP_CAPACITY).assertEquals(i)
+
+/**	Negative keys hash into range and stay distinct from their positive counterparts. */
+@Test function testNegativeIntKeys()
+	let map = new FastHashMap<int, int>()
+	map.put(-1, 10)
+	map.put(1, 20)
+	map.put(-65536, 30)
+	map.get(-1).assertEquals(10)
+	map.get(1).assertEquals(20)
+	map.get(-65536).assertEquals(30)
+	map.size().assertEquals(3)
+
+/**	Reaches the bound's requirement directly, which is the only way to see a hash rather than its
+	effect: probing separates colliding keys, so a map behaves correctly however badly its keys
+	hash and every test above passes with an identity hash and with `StringHash`. */
+function hashOf<T: Hashable>(T x) returns int
+	return T.hash(x)
+
+/**	Keys strided by the capacity must not all land in one slot. An identity hash sends every one
+	of them to slot zero, which probing then spreads over the following slots - correct, and it
+	fills a section of thirty two after sixteen such keys. Ids, handles and loop counters all
+	arrive strided like this. */
+@Test function testIntHashSpreadsKeysStridedByCapacity()
+	let firstSlot = hashOf(0) mod FASTHASHMAP_CAPACITY
+	var differing = 0
+	for i = 1 to 15
+		if hashOf(i * FASTHASHMAP_CAPACITY) mod FASTHASHMAP_CAPACITY != firstSlot
+			differing++
+	differing.assertGreaterThan(10)
+
+/**	`StringHash` is case insensitive, so a hash taken from it gave these two the same value. */
+@Test function testStringHashSeparatesCase()
+	(hashOf("alpha") != hashOf("ALPHA")).assertTrue()
+
+/**	Position and length reach the hash, not just the bytes present. */
+@Test function testStringHashSeparatesOrderAndLength()
+	(hashOf("ab") != hashOf("ba")).assertTrue()
+	(hashOf("ab") != hashOf("a")).assertTrue()
+
+/**	Equal keys must hash alike, which is the half of the contract a lookup depends on. */
+@Test function testEqualKeysHashAlike()
+	hashOf("alpha").assertEquals(hashOf("alp" + "ha"))
+	hashOf(4242).assertEquals(hashOf(4200 + 42))

--- a/wurst/data/FastHashMapTests.wurst
+++ b/wurst/data/FastHashMapTests.wurst
@@ -96,12 +96,12 @@ function testFullMapRefusesNewKeys()
 		map.put(i, i)
 	map.isFull().assertEquals(true)
 	map.size().assertEquals(FASTHASHMAP_CAPACITY)
-	map.put(FASTHASHMAP_CAPACITY + 1000, 1)
-	map.size().assertEquals(FASTHASHMAP_CAPACITY)
 	map.get(0).assertEquals(0)
-	// a key it already holds is still writable
+	// A key it already holds is still writable. A new one now reports instead of being dropped,
+	// which is what isFull is for, so this does not try it.
 	map.put(0, 99)
 	map.get(0).assertEquals(99)
+	map.size().assertEquals(FASTHASHMAP_CAPACITY)
 
 /** Two maps of the same types hold separate sections. */
 @Test
@@ -242,3 +242,66 @@ function hashOf<T: Hashable>(T x) returns int
 	let reused = new FastHashMap<int, int>()
 	reused.has(1).assertEquals(false)
 	keep.get(1).assertEquals(100)
+
+/**	Every entry is reachable by walking slots, and only the entries. */
+@Test function testIterationVisitsEveryEntryOnce()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 10)
+	map.put(1 + FASTHASHMAP_CAPACITY, 90)
+	map.put(5, 50)
+
+	var visited = 0
+	var keySum = 0
+	var valueSum = 0
+	var slot = map.nextEntry(0)
+	while slot >= 0
+		visited++
+		keySum += map.keyAt(slot)
+		valueSum += map.valueAt(slot)
+		slot = map.nextEntry(slot + 1)
+
+	visited.assertEquals(3)
+	keySum.assertEquals(1 + (1 + FASTHASHMAP_CAPACITY) + 5)
+	valueSum.assertEquals(150)
+
+/**	A removed key is not visited, and its tombstone does not stop the walk early. */
+@Test function testIterationSkipsRemovedEntries()
+	let map = new FastHashMap<int, int>()
+	map.put(1, 10)
+	map.put(1 + FASTHASHMAP_CAPACITY, 90)
+	map.remove(1)
+
+	var visited = 0
+	var keySum = 0
+	var slot = map.nextEntry(0)
+	while slot >= 0
+		visited++
+		keySum += map.keyAt(slot)
+		slot = map.nextEntry(slot + 1)
+
+	visited.assertEquals(1)
+	keySum.assertEquals(1 + FASTHASHMAP_CAPACITY)
+
+/**	An empty map has nothing to walk, and a cleared one goes back to that. */
+@Test function testIterationOfAnEmptyMap()
+	let map = new FastHashMap<int, int>()
+	map.nextEntry(0).assertEquals(-1)
+	map.put(3, 30)
+	(map.nextEntry(0) >= 0).assertTrue()
+	map.clear()
+	map.nextEntry(0).assertEquals(-1)
+
+/**	String keys iterate as themselves, the key being stored rather than an index for it. */
+@Test function testIterationOverStringKeys()
+	let map = new FastHashMap<string, int>()
+	map.put("alpha", 1)
+	map.put("beta", 2)
+	var joined = ""
+	var total = 0
+	var slot = map.nextEntry(0)
+	while slot >= 0
+		joined += map.keyAt(slot)
+		total += map.valueAt(slot)
+		slot = map.nextEntry(slot + 1)
+	joined.length().assertEquals("alpha".length() + "beta".length())
+	total.assertEquals(3)

--- a/wurst/data/FastHashMapTests.wurst
+++ b/wurst/data/FastHashMapTests.wurst
@@ -207,3 +207,38 @@ function hashOf<T: Hashable>(T x) returns int
 @Test function testEqualKeysHashAlike()
 	hashOf("alpha").assertEquals(hashOf("alp" + "ha"))
 	hashOf(4242).assertEquals(hashOf(4200 + 42))
+
+/**	A destroyed map hands its section back, so the instance count bounds live maps rather than
+	maps ever made. Without that, `nextFree` only grew and the map after the two hundred and fifty
+	sixth refused every key - which is what a map creating one per spell cast or per unit does. */
+@Test function testDestroyedSectionsAreReused()
+	for i = 0 to FASTHASHMAP_MAX_INSTANCES + 20
+		let map = new FastHashMap<int, int>()
+		map.put(i, i)
+		map.get(i).assertEquals(i)
+		destroy map
+
+/**	A reused section starts empty, or a new map would inherit the last one's keys. */
+@Test function testReusedSectionStartsEmpty()
+	let first = new FastHashMap<int, int>()
+	first.put(7, 70)
+	first.size().assertEquals(1)
+	destroy first
+
+	let second = new FastHashMap<int, int>()
+	second.has(7).assertEquals(false)
+	second.size().assertEquals(0)
+	second.get(7).assertEquals(0)
+	destroy second
+
+/**	Two maps alive at once keep separate sections across a destroy in between. */
+@Test function testLiveMapsKeepTheirSectionWhenAnotherIsDestroyed()
+	let keep = new FastHashMap<int, int>()
+	keep.put(1, 100)
+	let temporary = new FastHashMap<int, int>()
+	temporary.put(1, 200)
+	destroy temporary
+	keep.get(1).assertEquals(100)
+	let reused = new FastHashMap<int, int>()
+	reused.has(1).assertEquals(false)
+	keep.get(1).assertEquals(100)


### PR DESCRIPTION
`HashMap` casts every key to an int and stores it in a `Table`. That works for handles and for anything castable, but it loses the type on the way in: two keys which cast to the same int collide, and a key which is not castable cannot be used at all.

`FastHashMap` takes a bound on its key type instead, so hashing and comparing are done by the key's own implementation and the key is stored as itself:

```wurst
implements Hashable<vec2>
    function hash(vec2 v) returns int
        return v.x.toInt() * 31 + v.y.toInt()
    function equals(vec2 a, vec2 b) returns boolean
        return a == b

let seen = new FastHashMap<vec2, unit>()
seen.put(caster.getPos(), caster)
```

Instances for `int` and `string` come with the package. Declaring one beside your own type is what makes it usable as a key.

### Storage

One array per specialisation, carved into a section per instance, the way `ArrayList` works. A section is `FASTHASHMAP_CAPACITY` slots and does not grow; collisions probe linearly inside it, and a removed slot becomes a tombstone rather than empty so a probe which passed over it still finds keys put down beyond it.

A destroyed map hands its section back, so `FASTHASHMAP_MAX_INSTANCES` bounds maps *alive* rather than maps ever made. Every section is the same width, so released ones are a stack rather than the capacity-matched free list `ArrayList` keeps — any released section fits any new map, and there is nothing to compact. On the Jass target the configured total is also checked against `JASS_MAX_ARRAY_SIZE`, the storage being one fixed-size array.

### The hash is computed here

Neither instance takes a shortcut, because a section fills up: colliding keys do not merely probe longer, the map eventually refuses them.

`StringHash` is unusable for this. It is case insensitive, so `alpha` and `ALPHA` would share a slot, and it collapses every partial multibyte slice to one constant. The string hash mixes each byte with its position and the length instead, so anagrams and prefixes separate too. Single bytes still decode through `StringUtils.char`, which recovers the case `StringHash` loses and which the library already depends on throughout; non-latin text is the remaining weak case, its lead bytes not decoding, and the doc says so.

The int hash returned the key itself at first, which sends everything strided by the capacity to slot zero — ids, handles and loop counters all arrive strided like that. Halves are mixed separately so the multiplications stay in range.

Every intermediate stays below 2^31 rather than relying on overflow, which wraps at 32 bits on Jass and does not on Lua. Nothing stores a hash, so differing values would not have been wrong, but the interpreter could then no longer stand in for the game while testing distribution.

### Reporting and iteration

A full map reports a dropped write rather than discarding it silently — losing a store without a word is close to impossible to find from the outside. A key the map already holds stays writable, and `isFull()` asks beforehand.

Entries can be walked without allocating:

```wurst
var slot = map.nextEntry(0)
while slot >= 0
    doSomething(map.keyAt(slot), map.valueAt(slot))
    slot = map.nextEntry(slot + 1)
```

Slot walking rather than an iterator object or a closure: nothing is allocated, and it avoids dispatching a bound through a closure, which is not supported on every target. A `for in` wrapper can be layered on this.

### Compiler requirement

Type class bounds for `T:` generics, shipped in wurstscript/WurstScript#1226, #1228 and #1229. The bound is what makes the key's own `hash` and `equals` reachable from inside the generic, and it lowers to a direct call to the instance function after specialisation, on both Jass and Lua.

### Testing

`grill test` reports 489/489, of which 25 are this package's. Beyond the obvious behaviour — put/get, replacement, missing keys reading as the value type's default, colliding keys, removal keeping later keys reachable, tombstone reuse, independent instances, two specialisations coexisting — the tests cover the three things that would otherwise pass quietly:

- **The hash itself**, reached through a `hashOf<T: Hashable>` helper. The behavioural tests pass with an identity hash and with `StringHash`, because probing separates colliding keys however badly they hash; only observing the hash catches it. Against the old ones these fail with all sixteen strided keys in one slot and with `alpha` and `ALPHA` hashing alike.
- **Section reuse**, by creating and destroying past the instance limit. Without it, that reports `out of sections`.
- **Iteration**, including that tombstones are skipped and do not end the walk early.

Every test here was checked to fail before it passed.

### Note

The container is also exercised from the compiler side in `FastHashMapTests` there — standalone and with the standard library in scope, on both targets — since it is the shape the bounds feature was built for. One gap worth stating: the standard-library-in-scope case is compiled but not executed on Lua, because the test runtime shim cannot initialise the library's own packages.

A later step could give Lua a native table instead of this probing, which would lift `FASTHASHMAP_CAPACITY` there; that is wurstscript/WurstScript#1255, and it is deliberately not part of this.