### PR TITLE
Modernize stdlib with current Wurst features

### DIFF
--- a/wurst/StdlibIngameTests.wurst
+++ b/wurst/StdlibIngameTests.wurst
@@ -101,15 +101,12 @@ function setupUnits()
 
 function teardownUnits()
 	// null tolerant: setupUnits may itself have been the thing that crashed
-	if attacker != null
-		attacker.remove()
-		attacker = null
-	if victim != null
-		victim.remove()
-		victim = null
-	if victim2 != null
-		victim2.remove()
-		victim2 = null
+	attacker?.remove()
+	attacker = null
+	victim?.remove()
+	victim = null
+	victim2?.remove()
+	victim2 = null
 
 /**	Heals the victim, then deals `amount` as CODE damage.
 	Ordinary physical damage rather than the DAMAGE_TYPE_UNIVERSAL default of
@@ -731,9 +728,8 @@ function testSpatialIndexReentrancy()
 	destroy creationSnapshot
 	check(reentrancyVisited == 4, "creating a unit mid-iteration does not extend it ("
 		+ reentrancyVisited + ")")
-	if spawnedDuringQuery != null
-		spawnedDuringQuery.remove()
-		spawnedDuringQuery = null
+	spawnedDuringQuery?.remove()
+	spawnedDuringQuery = null
 
 	for i = 0 to 3
 		reentrancyProbes[i].remove()

--- a/wurst/closures/ClosureTimers.wurst
+++ b/wurst/closures/ClosureTimers.wurst
@@ -54,9 +54,9 @@ public function nullTimer(CallbackSingle cb) returns CallbackSingle
 	Must be used on a timer acquired with `getTimer()`
 
 	Example use:
-	| someTimer.doPeriodically(0.5) cb ->
+	| someTimer.doPeriodically(0.5) (_) ->
 	|	 if i > 10
-	|		destroy cb
+	|		destroy it
 */
 public function timer.doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
 	cb.start(this, time)
@@ -66,9 +66,9 @@ public function timer.doPeriodically(real time, CallbackPeriodic cb) returns Cal
 	The callback has to be destroyed manually.
 
 	Example use:
-	| doPeriodically(0.5) cb ->
+	| doPeriodically(0.5) (_) ->
 	|	 if i > 10
-	|		destroy cb
+	|		destroy it
 */
 public function doPeriodically(real time, CallbackPeriodic cb) returns CallbackPeriodic
 	return getTimer().doPeriodically(time, cb)
@@ -78,7 +78,7 @@ public function doPeriodically(real time, CallbackPeriodic cb) returns CallbackP
 	Must be used on a timer acquired with `getTimer()`
 
 	Example use:
-	| someTimer.doPeriodicallyCounted(0.5, 100) cb ->
+	| someTimer.doPeriodicallyCounted(0.5, 100) (_) ->
 	|	 doSomething()
 
 */
@@ -90,7 +90,7 @@ public function timer.doPeriodicallyCounted(real time, int callAmount, CallbackC
 	The callback object is destroyed after the action has been executed callAmount times.
 
 	Example use:
-	| doPeriodicallyCounted(0.5, 100) cb ->
+	| doPeriodicallyCounted(0.5, 100) (_) ->
 	|	 doSomething()
 
 */

--- a/wurst/closures/ClosureTimersTests.wurst
+++ b/wurst/closures/ClosureTimersTests.wurst
@@ -13,17 +13,17 @@ var x = 200
 		x.assertEquals(250)
 
 	var _count = 3
-	let cb = doPeriodicallyCounted(3, 3) (CallbackCounted cb) ->
-		cb.getCount().assertEquals(_count)
-		if cb.isLast()
-			cb.progress().assertEquals(1, 0.0001)
-			cb.getCount().assertEquals(1)
+	let cb = doPeriodicallyCounted(3, 3) (_) ->
+		it.getCount().assertEquals(_count)
+		if it.isLast()
+			it.progress().assertEquals(1, 0.0001)
+			it.getCount().assertEquals(1)
 		else if _count == 3
-			cb.progress().assertEquals(0.33333, 0.00001)
-			cb.getCount().assertEquals(3)
+			it.progress().assertEquals(0.33333, 0.00001)
+			it.getCount().assertEquals(3)
 		else if _count == 2
-			cb.progress().assertEquals(0.66666, 0.00001)
-			cb.getCount().assertEquals(2)
+			it.progress().assertEquals(0.66666, 0.00001)
+			it.getCount().assertEquals(2)
 		_count--
 	cb.progress().assertEquals(0, 0.00001)
 	cb.getCount().assertEquals(_count)

--- a/wurst/data/PriorityQueue.wurst
+++ b/wurst/data/PriorityQueue.wurst
@@ -23,8 +23,8 @@ import ArrayList
  * remove and re-add it after changing any fields used by the comparator.
  */
 public class PriorityQueue<T:>
-    private ArrayList<T> values
-    private Comparator<T> comparator
+    private readonly ArrayList<T> values
+    private readonly Comparator<T> comparator
 
     construct(Comparator<T> comparator)
         this(comparator, 16)

--- a/wurst/data/SparseSet.wurst
+++ b/wurst/data/SparseSet.wurst
@@ -22,10 +22,10 @@ public interface SparseSetKey<T:>
  * iteration order is not preserved.
  */
 public class SparseSet<T:>
-    private ArrayList<T> dense
-    private ArrayList<int> denseKeys
-    private Table sparse
-    private SparseSetKey<T> keyProvider
+    private readonly ArrayList<T> dense
+    private readonly ArrayList<int> denseKeys
+    private readonly Table sparse
+    private readonly SparseSetKey<T> keyProvider
 
     construct(SparseSetKey<T> keyProvider)
         this.keyProvider = keyProvider

--- a/wurst/dummy/Fx.wurst
+++ b/wurst/dummy/Fx.wurst
@@ -68,9 +68,8 @@ public class Fx
 
 	/** Set the owner of this Fx Object */
 	function setOwner(player p, boolean changeColor)
-		if fx != null
-			fx.destr()
-			fx = null
+		fx?.destr()
+		fx = null
 		setFx(sfxPath)
 		dummy.setOwner(p, changeColor)
 
@@ -169,8 +168,7 @@ public class Fx
 	/** Set the path to the sfx model that should be displayed.
 	If there is already a model displayed, it will be replaced with the new one.*/
 	function setFx(string newpath)
-		if fx != null
-			fx.destr()
+		fx?.destr()
 		if newpath == ""
 			fx = null
 		else
@@ -178,8 +176,7 @@ public class Fx
 		sfxPath = newpath
 
 	ondestroy
-		if fx != null
-			fx.destr()
+		fx?.destr()
 
 		DummyRecycler.recycle(dummy, 1.)
 

--- a/wurst/event/DamageEvent.wurst
+++ b/wurst/event/DamageEvent.wurst
@@ -123,9 +123,9 @@ class DamageInstance
     protected real unreducedAmount
     protected readonly real unreducedOriginalAmount
     protected bool unreduced
-    protected readonly attacktype nativeAttackType
-    protected readonly damagetype nativeDamageType
-    protected readonly weapontype nativeWeaponType
+    protected attacktype nativeAttackType
+    protected damagetype nativeDamageType
+    protected weapontype nativeWeaponType
     protected readonly DamageType damageType
     protected readonly DamageElement damageElement
 

--- a/wurst/event/DamageEvent.wurst
+++ b/wurst/event/DamageEvent.wurst
@@ -115,19 +115,19 @@ public class DamageElement
 /* DAMAGE INSTANCE */
 
 class DamageInstance
-    protected int id
-    protected unit source
-    protected unit target
+    protected readonly int id
+    protected readonly unit source
+    protected readonly unit target
     protected real amount
-    protected real originalAmount
+    protected readonly real originalAmount
     protected real unreducedAmount
-    protected real unreducedOriginalAmount
+    protected readonly real unreducedOriginalAmount
     protected bool unreduced
-    protected attacktype nativeAttackType
-    protected damagetype nativeDamageType
-    protected weapontype nativeWeaponType
-    protected DamageType damageType
-    protected DamageElement damageElement
+    protected readonly attacktype nativeAttackType
+    protected readonly damagetype nativeDamageType
+    protected readonly weapontype nativeWeaponType
+    protected readonly DamageType damageType
+    protected readonly DamageElement damageElement
 
     protected static thistype current = null
     protected static thistype array stack

--- a/wurst/file/ByteBuffer.wurst
+++ b/wurst/file/ByteBuffer.wurst
@@ -14,7 +14,7 @@ import ErrorHandling
 public class ByteBuffer
 	// We're using Table instead of HashMap here since HashMap has additional checks to maintain know it's size,
 	// which are unneeded here and slow the container 2x.
-	private var storage = new Table()
+	private readonly Table storage = new Table()
 	private var intCount = 0
 
 	private var buffer = 0

--- a/wurst/file/ChunkedString.wurst
+++ b/wurst/file/ChunkedString.wurst
@@ -30,8 +30,8 @@ import Table
 @configurable public constant DEFAULT_CHUNK_SIZE = 200
 
 public class ChunkedString
-	private Table table = new Table()
-	private var chunkSize = DEFAULT_CHUNK_SIZE
+	private readonly Table table = new Table()
+	private readonly var chunkSize = DEFAULT_CHUNK_SIZE
 	protected var chunkCount = 0
 	private var readIndex = -1
 	protected var buffer = ""

--- a/wurst/file/SQLite.wurst
+++ b/wurst/file/SQLite.wurst
@@ -92,7 +92,7 @@ public class SqlResult
 
 /** Wraps an SQLite database connection with convenience methods. */
 public class SqliteDb
-    private int conn
+    private readonly int conn
 
     /** Opens (or creates) the database at the given path. Use ":memory:" for temporary databases. */
     construct(string path)

--- a/wurst/math/Polygon.wurst
+++ b/wurst/math/Polygon.wurst
@@ -407,8 +407,7 @@ public class Polygon
 			ShardedIntStorage.release(gridStorageStart, gridStorageSize)
 		gridStorageStart = -1
 		gridStorageSize = 0
-		if boundaryRect != null
-			boundaryRect.remove()
-			boundaryRect = null
+		boundaryRect?.remove()
+		boundaryRect = null
 		destroy vertices
 		vertices = null

--- a/wurst/util/Board.wurst
+++ b/wurst/util/Board.wurst
@@ -184,11 +184,13 @@ public class Board
     function removeRow(BoardRow row)
         rows.remove(row)
         board.setRowCount(rows.size())
-		var i = 0
-		rows.forEach() row ->
-			row.rowIndex = i
-			row.invalidate()
-			i++
+        let i = reference(0)
+        rows.forEach() row ->
+            row.rowIndex = i.val
+            row.invalidate()
+            i.val++
+
+        destroy i
 
     /** Unsafe access to the underlying multiboard */
     function getBoard() returns multiboard

--- a/wurst/util/Board.wurst
+++ b/wurst/util/Board.wurst
@@ -184,13 +184,11 @@ public class Board
     function removeRow(BoardRow row)
         rows.remove(row)
         board.setRowCount(rows.size())
-        let i = reference(0)
-        rows.forEach() row ->
-            row.rowIndex = i.val
-            row.invalidate()
-            i.val++
-
-        destroy i
+		var i = 0
+		rows.forEach() row ->
+			row.rowIndex = i
+			row.invalidate()
+			i++
 
     /** Unsafe access to the underlying multiboard */
     function getBoard() returns multiboard

--- a/wurst/util/DialogBox.wurst
+++ b/wurst/util/DialogBox.wurst
@@ -41,8 +41,7 @@ public class DialogBox
 	private static function runClickedButton()
 		let btn = GetClickedButton()
 		let cb = buttonClosures.get(btn)
-		if cb != null
-			cb.run()
+		cb?.run()
 
 	function addButton(string buttonText)
 		this.addButton(buttonText, 0 , null)

--- a/wurst/util/EffectUtils.wurst
+++ b/wurst/util/EffectUtils.wurst
@@ -7,16 +7,14 @@ import MapBounds
 /** remove effect after "time" expires*/
 public function effect.destrAfter(real time)
 	doAfter(time) ->
-		if this != null
-			this.destr()
+		this?.destr()
 
 /** After "time", move effect to invisible part of map before removing it (which plays death animation).
 	Does not work on effects attached to units!
 */
 public function effect.destrHiddenAfter(real time)
 	doAfter(time) ->
-		if this != null
-			this.destrHidden()
+		this?.destrHidden()
 
 /** Move effect to invisible part of map before removing it (which plays death animation).
 	Does not work on effects attached to units!


### PR DESCRIPTION
## Summary

- Modernize safe no-op null handling with Wurst's `?.` operator.
- Use closure self-reference via `it` in timer examples and tests without changing callback signatures.
- Replace a temporary `Reference` wrapper with captured mutable closure state in `Board.removeRow`.
- Add `readonly` to private or package-internal state whose owning code already controls all writes.

## Compatibility

Consumer-facing callback signatures and public/protected writable fields are unchanged. Behavior-sensitive null checks remain explicit.

## Checks

- `grill typecheck --quiet`
- `grill test --quiet`
- `git diff --check`

All checks passed locally.

## Known gaps

No Warcraft III engine/e2e run was needed for these syntax-equivalent refactors; runtime multiplayer behavior was not changed.
