### PR TITLE
Add preserveName annotation to magic functions

### DIFF
--- a/wurst/_wurst/MagicFunctions.wurst
+++ b/wurst/_wurst/MagicFunctions.wurst
@@ -32,6 +32,9 @@ The called functions must not take any parameters.
 */
 public function callFunctionsWithAnnotation(string _annotation)
 
+/** Prevents -opt name minification for a top-level function whose name is used externally. */
+@annotation public function preserveName()
+
 /** this is a magic constant.
 It is always false at runtime and true during compiletime.
 */


### PR DESCRIPTION
## Summary

- Add the public `@preserveName` annotation declaration to the compiler magic-functions package.
- Document that it preserves externally referenced top-level function names when `-opt` name minification is enabled.

## Checks

- `grill typecheck --quiet`

## Scope

This exposes the annotation to stdlib consumers; the compiler implementation is provided by the WurstScript compiler PR.
