### PR TITLE
Add SpatialPartition: one generic grid for the spatial indexes to share

### DIFF
--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -25,10 +25,11 @@ package SpatialPartition
 	sentinel. `rebuildSpatialPartition` must give the grid an extent before any entry is added.
 
 	Like the indexes built on it, this targets **Lua**, where arrays grow dynamically. The cell chains
-	are flattened as `cell * MAX_GROUPS + groupId`, so the storage a grid needs is
-	`gridWidth * gridHeight * SPATIAL_PARTITION_MAX_GROUPS` slots - which on the Jass target is bounded
-	by `JASS_MAX_ARRAY_SIZE`, and a large extent at a small cell size exceeds it. `rebuildSpatialPartition`
-	refuses such a grid there rather than silently losing the cells past the limit.
+	are flattened as `cell * MAX_GROUPS + groupId` and the per-entry links as `id * MAX_GROUPS + groupId`,
+	so both a grid extent and an entry id have a ceiling on Jass, where arrays are fixed at
+	`JASS_MAX_ARRAY_SIZE`. `rebuildSpatialPartition` refuses an extent past that ceiling and
+	`spatialPartitionMaxEntryId` reports the other, rather than either silently losing what it cannot
+	address.
 */
 import ErrorHandling
 
@@ -150,9 +151,20 @@ public function spatialPartitionLastQueryBlocksSkipped() returns int
 	invisible to every query and, worse, letting a later unlink overwrite the real head and hide every
 	other entry in the same cell. Rejecting is cheaper than encoding ids as `id + 1`, which would put an
 	extra add and subtract in the hottest loop in the package. */
-/** Whether an id may be used as an entry. Ids are 1-based; 0 is reserved as the chain sentinel. */
+/*	Both flattened address spaces are bounded by the target, and by the same constant.
+
+	Cells are addressed as `cell * MAX_GROUPS + groupId` and entries as `id * MAX_GROUPS + groupId`, so
+	each has a ceiling on Jass where arrays are fixed. `rebuildSpatialPartition` enforces the first;
+	this enforces the second, and bounding entry ids covers the rest transitively - the snapshot and the
+	registry are indexed by counts that cannot exceed the live entries. On Lua arrays grow and neither
+	ceiling applies. */
+public function spatialPartitionMaxEntryId() returns int
+	return isLua ? INT_MAX : JASS_MAX_ARRAY_SIZE div SPATIAL_PARTITION_MAX_GROUPS - 1
+
+/**	Whether an id may be used as an entry. Ids are 1-based, because 0 is reserved as the chain
+	sentinel, and bounded above on Jass by what the flattened entry slots can address. */
 public function spatialPartitionIsValidEntryId(int id) returns boolean
-	return id >= 1
+	return id >= 1 and id <= spatialPartitionMaxEntryId()
 
 /** Whether a group id addresses a real group. */
 public function spatialPartitionIsValidGroupId(int groupId) returns boolean
@@ -168,7 +180,8 @@ public function spatialPartitionIsReady() returns boolean
 	reads entry 2's group 0. Silence would be a wrong answer rather than no answer. */
 function requireValidEntry(int id) returns boolean
 	if not spatialPartitionIsValidEntryId(id)
-		error("SpatialPartition: entry id " + id + " is invalid; ids are 1-based (0 is the chain sentinel)")
+		error("SpatialPartition: entry id " + id + " is invalid; ids are 1-based and at most "
+			+ spatialPartitionMaxEntryId() + " on this target")
 		return false
 	return true
 

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -1,0 +1,344 @@
+package SpatialPartition
+/*	Backend-agnostic uniform-grid spatial partition over integer entry ids.
+
+	This is the structure, not a unit index. It knows ids, positions and group membership; it does not
+	know what an id refers to, when a position becomes stale, or what "visible" means. Those belong to
+	the consuming layer, which is what lets one structure serve moving units and static destructables
+	without either paying for the other's concerns.
+
+	Three deliberate properties, in the order they matter to the emitted Lua:
+
+	1. No allocation per query. Every buffer is a preallocated flat array and results are read out of a
+	   shared snapshot stack. Wurst arrays become Lua tables, and a flat table with index arithmetic is
+	   one array-part lookup where a nested table would be two.
+	2. No calls in the walk. Group membership is pushed in by the caller rather than pulled through a
+	   predicate, and an undecidable position is reported as a flag for the caller to resolve rather
+	   than dispatched through an interface. A call per entry is the most expensive thing this loop
+	   could do.
+	3. Empty space is skipped, not walked. A coarse occupancy level over the fine grid makes a large
+	   radius cost the blocks that actually hold members instead of every cell in its bounding box.
+
+	Staleness is a query parameter, not state: a caller whose entries never move passes a zero
+	displacement and gets an exact answer with no undecidable band at all.
+*/
+import ErrorHandling
+
+// Configuration
+
+/** Fine cell edge in world units. Smaller tightens windows but walks more cells. */
+@configurable public constant SPATIAL_PARTITION_CELL_SIZE = 256.
+
+/**	Fine cells per coarse block edge, so 8 means a block covers 8x8 cells. The coarse level exists so
+	a large query skips empty regions with one test per block instead of one per cell. */
+@configurable public constant SPATIAL_PARTITION_COARSE_FACTOR = 8
+
+/**	Concurrently declared groups. Each costs one chain pointer per entry and one head per cell, so
+	raise it only as far as a project uses. */
+@configurable public constant SPATIAL_PARTITION_MAX_GROUPS = 8
+
+// Grid state
+
+var gridOriginX = 0.
+var gridOriginY = 0.
+var gridWidth = 0
+var gridHeight = 0
+var coarseWidth = 0
+var coarseHeight = 0
+
+/*	Chains are flattened with a constant stride, since Wurst has no per-instance arrays: an entry slot
+	for a group is `id * MAX_GROUPS + groupId` and a cell head is `cell * MAX_GROUPS + groupId`. One
+	multiply and an add beats a second table indirection in Lua. */
+int array cellHead
+int array nextInCell
+int array prevInCell
+/** Cell + 1 an entry is linked under for a group; 0 means it is not a member of that group. */
+int array cellOfEntry
+/** Members of each group inside each coarse block, so an empty block is skipped without descending. */
+int array coarseCount
+real array entryX
+real array entryY
+
+/*	Dense list of live entries. The partition needs to know its own population for one reason it cannot
+	delegate: a grid rebuild changes what every cell index means, so every entry has to be re-linked,
+	and an owning layer cannot do that through an API that has already forgotten them. */
+int array registryIds
+/** Registry slot + 1 for a live entry, 0 for one the partition does not know. */
+int array registrySlot
+var registryCount = 0
+/** Scratch used only across a rebuild, to carry membership over the re-link. */
+boolean array rebuildMember
+
+// Query snapshot
+
+int array snapshotId
+boolean array snapshotUncertain
+var snapshotTop = 0
+int array queryBase
+var queryDepth = 0
+var lastQueryVisits = 0
+var lastQueryBlocksSkipped = 0
+
+// Grid math
+
+@inline function cellCoordX(real x) returns int
+	return max(0, min(gridWidth - 1, ((x - gridOriginX) / SPATIAL_PARTITION_CELL_SIZE).floor()))
+
+@inline function cellCoordY(real y) returns int
+	return max(0, min(gridHeight - 1, ((y - gridOriginY) / SPATIAL_PARTITION_CELL_SIZE).floor()))
+
+@inline function cellAt(real x, real y) returns int
+	return cellCoordX(x) + cellCoordY(y) * gridWidth
+
+@inline function groupSlot(int id, int groupId) returns int
+	return id * SPATIAL_PARTITION_MAX_GROUPS + groupId
+
+@inline function headSlot(int cell, int groupId) returns int
+	return cell * SPATIAL_PARTITION_MAX_GROUPS + groupId
+
+@inline function coarseSlot(int block, int groupId) returns int
+	return block * SPATIAL_PARTITION_MAX_GROUPS + groupId
+
+@inline function blockOfCell(int cell) returns int
+	return ((cell mod gridWidth) div SPATIAL_PARTITION_COARSE_FACTOR)
+		+ ((cell div gridWidth) div SPATIAL_PARTITION_COARSE_FACTOR) * coarseWidth
+
+/** Fine cell for a position, for tests and diagnostics. */
+public function spatialPartitionCellOf(vec2 pos) returns int
+	return cellAt(pos.x, pos.y)
+
+public function spatialPartitionGridWidth() returns int
+	return gridWidth
+
+public function spatialPartitionGridHeight() returns int
+	return gridHeight
+
+public function spatialPartitionCoarseWidth() returns int
+	return coarseWidth
+
+/** Entries the last query walked, whether or not they matched. */
+public function spatialPartitionLastQueryVisits() returns int
+	return lastQueryVisits
+
+/** Coarse blocks the last query rejected without descending into their cells. */
+public function spatialPartitionLastQueryBlocksSkipped() returns int
+	return lastQueryBlocksSkipped
+
+// Membership
+
+function linkIntoCell(int id, int groupId, int cell)
+	let slot = groupSlot(id, groupId)
+	let head = cellHead[headSlot(cell, groupId)]
+	prevInCell[slot] = 0
+	nextInCell[slot] = head
+	if head != 0
+		prevInCell[groupSlot(head, groupId)] = id
+	cellHead[headSlot(cell, groupId)] = id
+	cellOfEntry[slot] = cell + 1
+	let block = coarseSlot(blockOfCell(cell), groupId)
+	coarseCount[block] = coarseCount[block] + 1
+
+function unlinkFromCell(int id, int groupId)
+	let slot = groupSlot(id, groupId)
+	let stored = cellOfEntry[slot]
+	if stored == 0
+		return
+	let cell = stored - 1
+	let prev = prevInCell[slot]
+	let next = nextInCell[slot]
+	if prev != 0
+		nextInCell[groupSlot(prev, groupId)] = next
+	else
+		cellHead[headSlot(cell, groupId)] = next
+	if next != 0
+		prevInCell[groupSlot(next, groupId)] = prev
+	cellOfEntry[slot] = 0
+	nextInCell[slot] = 0
+	prevInCell[slot] = 0
+	let block = coarseSlot(blockOfCell(cell), groupId)
+	coarseCount[block] = coarseCount[block] - 1
+
+/**	Records where an entry is, re-bucketing it in every group it belongs to. Call this before adding
+	the entry to any group, and again whenever it has moved. */
+public function spatialPartitionSetPos(int id, real x, real y)
+	entryX[id] = x
+	entryY[id] = y
+	if registrySlot[id] == 0
+		registryIds[registryCount] = id
+		registryCount++
+		registrySlot[id] = registryCount
+	let cell = cellAt(x, y)
+	for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+		let slot = groupSlot(id, groupId)
+		if cellOfEntry[slot] != 0 and cellOfEntry[slot] != cell + 1
+			unlinkFromCell(id, groupId)
+			linkIntoCell(id, groupId, cell)
+
+/**	Adds or removes an entry from one group. The caller owns the policy of when membership changes,
+	which keeps predicate evaluation out of the walk entirely. */
+public function spatialPartitionSetGroup(int id, int groupId, boolean member)
+	if groupId < 0 or groupId >= SPATIAL_PARTITION_MAX_GROUPS
+		error("SpatialPartition: group " + groupId + " is outside SPATIAL_PARTITION_MAX_GROUPS")
+		return
+	let isMember = cellOfEntry[groupSlot(id, groupId)] != 0
+	if member and not isMember
+		linkIntoCell(id, groupId, cellAt(entryX[id], entryY[id]))
+	else if not member and isMember
+		unlinkFromCell(id, groupId)
+
+/** Whether an entry is currently in a group. */
+public function spatialPartitionInGroup(int id, int groupId) returns boolean
+	return cellOfEntry[groupSlot(id, groupId)] != 0
+
+/** Drops an entry from every group. Call before recycling its id, or a later entry inherits it. */
+public function spatialPartitionRemove(int id)
+	for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+		unlinkFromCell(id, groupId)
+	entryX[id] = 0.
+	entryY[id] = 0.
+	let slot = registrySlot[id]
+	if slot != 0
+		// Swap-remove keeps the list dense so a full pass never walks holes.
+		let last = registryCount - 1
+		let moved = registryIds[last]
+		registryIds[slot - 1] = moved
+		registrySlot[moved] = slot
+		registryIds[last] = 0
+		registryCount = last
+		registrySlot[id] = 0
+
+/** Live entries the partition holds. */
+public function spatialPartitionEntryCount() returns int
+	return registryCount
+
+/** Drops every entry and every group link. */
+public function spatialPartitionClear()
+	while registryCount > 0
+		spatialPartitionRemove(registryIds[registryCount - 1])
+
+/**	Re-derives the extent and re-links every entry into the new grid, keeping the groups they were in.
+
+	Every cell index means something different afterwards, so this cannot just clear the heads: an
+	entry still carrying its old link would be invisible to the new grid and would corrupt the chain it
+	is eventually unlinked from. */
+public function rebuildSpatialPartition(vec2 worldMin, vec2 worldMax)
+	// Old dimensions still describe the arrays being cleared, so clear before re-deriving them.
+	for cell = 0 to gridWidth * gridHeight - 1
+		for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+			cellHead[headSlot(cell, groupId)] = 0
+	for block = 0 to coarseWidth * coarseHeight - 1
+		for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+			coarseCount[coarseSlot(block, groupId)] = 0
+	for i = 0 to registryCount - 1
+		let id = registryIds[i]
+		for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+			let slot = groupSlot(id, groupId)
+			rebuildMember[slot] = cellOfEntry[slot] != 0
+			cellOfEntry[slot] = 0
+			nextInCell[slot] = 0
+			prevInCell[slot] = 0
+
+	gridOriginX = worldMin.x
+	gridOriginY = worldMin.y
+	gridWidth = ((worldMax.x - worldMin.x) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
+	gridHeight = ((worldMax.y - worldMin.y) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
+	coarseWidth = (gridWidth - 1) div SPATIAL_PARTITION_COARSE_FACTOR + 1
+	coarseHeight = (gridHeight - 1) div SPATIAL_PARTITION_COARSE_FACTOR + 1
+
+	for i = 0 to registryCount - 1
+		let id = registryIds[i]
+		let cell = cellAt(entryX[id], entryY[id])
+		for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
+			if rebuildMember[groupSlot(id, groupId)]
+				linkIntoCell(id, groupId, cell)
+
+// Queries
+
+@inline function pushMatch(int id, boolean uncertain)
+	snapshotId[snapshotTop] = id
+	snapshotUncertain[snapshotTop] = uncertain
+	snapshotTop++
+
+/**	Collects the members of `groupId` within `radius` of the point, allowing for entries whose cached
+	position may be up to `maxDisplacement` out of date.
+
+	Certainly-in and certainly-out are settled from the cached position alone. Entries in the
+	`maxDisplacement`-wide band around the boundary cannot be decided from stale data, so they come
+	back flagged: check `spatialPartitionQueryUncertain(i)` and resolve those against a live position.
+	Pass a zero displacement and no result is ever flagged.
+
+	Must be paired with `spatialPartitionEndQuery()`. */
+public function spatialPartitionBeginRangeQuery(vec2 center, real radius, real maxDisplacement,
+		int groupId) returns int
+	queryBase[queryDepth] = snapshotTop
+	queryDepth++
+	lastQueryVisits = 0
+	lastQueryBlocksSkipped = 0
+	if groupId < 0 or groupId >= SPATIAL_PARTITION_MAX_GROUPS or gridWidth <= 0
+		return 0
+
+	let reach = radius + maxDisplacement
+	let certainlyIn = radius - maxDisplacement
+	let certainlyInSq = certainlyIn * certainlyIn
+	let certainlyOutSq = reach * reach
+
+	let minCx = cellCoordX(center.x - reach)
+	let maxCx = cellCoordX(center.x + reach)
+	let minCy = cellCoordY(center.y - reach)
+	let maxCy = cellCoordY(center.y + reach)
+
+	// Walk coarse blocks and descend only into those holding a member of this group. A large radius
+	// over mostly empty space is the case this exists for: thousands of empty-cell visits become tens
+	// of block tests.
+	let minBx = minCx div SPATIAL_PARTITION_COARSE_FACTOR
+	let maxBx = maxCx div SPATIAL_PARTITION_COARSE_FACTOR
+	let minBy = minCy div SPATIAL_PARTITION_COARSE_FACTOR
+	let maxBy = maxCy div SPATIAL_PARTITION_COARSE_FACTOR
+
+	var by = minBy
+	while by <= maxBy
+		var bx = minBx
+		while bx <= maxBx
+			if coarseCount[coarseSlot(bx + by * coarseWidth, groupId)] <= 0
+				lastQueryBlocksSkipped++
+			else
+				let cellMinX = max(minCx, bx * SPATIAL_PARTITION_COARSE_FACTOR)
+				let cellMaxX = min(maxCx,
+					bx * SPATIAL_PARTITION_COARSE_FACTOR + SPATIAL_PARTITION_COARSE_FACTOR - 1)
+				let cellMinY = max(minCy, by * SPATIAL_PARTITION_COARSE_FACTOR)
+				let cellMaxY = min(maxCy,
+					by * SPATIAL_PARTITION_COARSE_FACTOR + SPATIAL_PARTITION_COARSE_FACTOR - 1)
+				var cy = cellMinY
+				while cy <= cellMaxY
+					let rowBase = cy * gridWidth
+					var cx = cellMinX
+					while cx <= cellMaxX
+						var id = cellHead[headSlot(rowBase + cx, groupId)]
+						while id != 0
+							let next = nextInCell[groupSlot(id, groupId)]
+							lastQueryVisits++
+							let dx = entryX[id] - center.x
+							let dy = entryY[id] - center.y
+							let distSq = dx * dx + dy * dy
+							if distSq <= certainlyOutSq
+								pushMatch(id, not (certainlyIn > 0. and distSq <= certainlyInSq))
+							id = next
+						cx++
+					cy++
+			bx++
+		by++
+
+	return snapshotTop - queryBase[queryDepth - 1]
+
+/** Entry id `i` of the innermost active query. */
+public function spatialPartitionQueryId(int i) returns int
+	return snapshotId[queryBase[queryDepth - 1] + i]
+
+/**	Whether entry `i` could not be decided from its cached position and needs a live check against the
+	requested radius. Always false when the query passed a zero displacement. */
+public function spatialPartitionQueryUncertain(int i) returns boolean
+	return snapshotUncertain[queryBase[queryDepth - 1] + i]
+
+public function spatialPartitionEndQuery()
+	if queryDepth > 0
+		queryDepth--
+		snapshotTop = queryBase[queryDepth]

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -1,5 +1,5 @@
 package SpatialPartition
-/*	Backend-agnostic uniform-grid spatial partition over integer entry ids.
+/*	Uniform-grid spatial partition over integer entry ids, agnostic about what those ids refer to.
 
 	This is the structure, not a unit index. It knows ids, positions and group membership; it does not
 	know what an id refers to, when a position becomes stale, or what "visible" means. Those belong to
@@ -23,6 +23,12 @@ package SpatialPartition
 
 	Entry ids are supplied by the owning layer and must be **1-based**: 0 is reserved as the chain
 	sentinel. `rebuildSpatialPartition` must give the grid an extent before any entry is added.
+
+	Like the indexes built on it, this targets **Lua**, where arrays grow dynamically. The cell chains
+	are flattened as `cell * MAX_GROUPS + groupId`, so the storage a grid needs is
+	`gridWidth * gridHeight * SPATIAL_PARTITION_MAX_GROUPS` slots - which on the Jass target is bounded
+	by `JASS_MAX_ARRAY_SIZE`, and a large extent at a small cell size exceeds it. `rebuildSpatialPartition`
+	refuses such a grid there rather than silently losing the cells past the limit.
 */
 import ErrorHandling
 
@@ -117,6 +123,17 @@ public function spatialPartitionGridHeight() returns int
 
 public function spatialPartitionCoarseWidth() returns int
 	return coarseWidth
+
+/**	Flattened cell-head slots the current grid occupies: one per cell per group. On Jass this must stay
+	within `JASS_MAX_ARRAY_SIZE`; on Lua arrays grow and it is only a memory figure. */
+public function spatialPartitionCellSlotCount() returns int
+	return gridWidth * gridHeight * SPATIAL_PARTITION_MAX_GROUPS
+
+/** Slots the given extent would need, so a caller can size cells and groups before committing to it. */
+public function spatialPartitionRequiredCellSlots(vec2 worldMin, vec2 worldMax) returns int
+	let w = ((worldMax.x - worldMin.x) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
+	let h = ((worldMax.y - worldMin.y) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
+	return w * h * SPATIAL_PARTITION_MAX_GROUPS
 
 /** Entries the last query walked, whether or not they matched. */
 public function spatialPartitionLastQueryVisits() returns int
@@ -270,6 +287,14 @@ public function spatialPartitionClear()
 	entry still carrying its old link would be invisible to the new grid and would corrupt the chain it
 	is eventually unlinked from. */
 public function rebuildSpatialPartition(vec2 worldMin, vec2 worldMax)
+	// The flattened cell storage has to be representable on the target before anything is cleared, or
+	// the refusal would leave the partition in a worse state than it started.
+	if not isLua and spatialPartitionRequiredCellSlots(worldMin, worldMax) > JASS_MAX_ARRAY_SIZE
+		error("SpatialPartition: that extent needs "
+			+ spatialPartitionRequiredCellSlots(worldMin, worldMax)
+			+ " cell slots, past this target's array limit of " + JASS_MAX_ARRAY_SIZE
+			+ "; raise SPATIAL_PARTITION_CELL_SIZE or lower SPATIAL_PARTITION_MAX_GROUPS")
+		return
 	// Old dimensions still describe the arrays being cleared, so clear before re-deriving them.
 	for cell = 0 to gridWidth * gridHeight - 1
 		for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -22,7 +22,7 @@ package SpatialPartition
 	displacement and gets an exact answer with no undecidable band at all.
 
 	Entry ids are supplied by the owning layer and must be **1-based**: 0 is reserved as the chain
-	sentinel.
+	sentinel. `rebuildSpatialPartition` must give the grid an extent before any entry is added.
 */
 import ErrorHandling
 
@@ -137,9 +137,33 @@ public function spatialPartitionLastQueryBlocksSkipped() returns int
 public function spatialPartitionIsValidEntryId(int id) returns boolean
 	return id >= 1
 
+/** Whether a group id addresses a real group. */
+public function spatialPartitionIsValidGroupId(int groupId) returns boolean
+	return groupId >= 0 and groupId < SPATIAL_PARTITION_MAX_GROUPS
+
+/** Whether the grid has been given an extent yet. Nothing can be linked before it has. */
+public function spatialPartitionIsReady() returns boolean
+	return gridWidth > 0 and gridHeight > 0
+
+/*	Every public mutator validates through these, and every public reader answers quietly for input it
+	cannot honour. Both halves matter because the arrays are flattened with a constant stride: an
+	out-of-range id does not fail, it ALIASES - `spatialPartitionInGroup(1, 8)` at the default stride
+	reads entry 2's group 0. Silence would be a wrong answer rather than no answer. */
 function requireValidEntry(int id) returns boolean
 	if not spatialPartitionIsValidEntryId(id)
 		error("SpatialPartition: entry id " + id + " is invalid; ids are 1-based (0 is the chain sentinel)")
+		return false
+	return true
+
+function requireValidGroup(int groupId) returns boolean
+	if not spatialPartitionIsValidGroupId(groupId)
+		error("SpatialPartition: group " + groupId + " is outside SPATIAL_PARTITION_MAX_GROUPS")
+		return false
+	return true
+
+function requireReady() returns boolean
+	if not spatialPartitionIsReady()
+		error("SpatialPartition: rebuildSpatialPartition must set an extent before entries are added")
 		return false
 	return true
 
@@ -178,7 +202,7 @@ function unlinkFromCell(int id, int groupId)
 /**	Records where an entry is, re-bucketing it in every group it belongs to. Call this before adding
 	the entry to any group, and again whenever it has moved. */
 public function spatialPartitionSetPos(int id, real x, real y)
-	if not requireValidEntry(id)
+	if not requireValidEntry(id) or not requireReady()
 		return
 	entryX[id] = x
 	entryY[id] = y
@@ -196,10 +220,7 @@ public function spatialPartitionSetPos(int id, real x, real y)
 /**	Adds or removes an entry from one group. The caller owns the policy of when membership changes,
 	which keeps predicate evaluation out of the walk entirely. */
 public function spatialPartitionSetGroup(int id, int groupId, boolean member)
-	if not requireValidEntry(id)
-		return
-	if groupId < 0 or groupId >= SPATIAL_PARTITION_MAX_GROUPS
-		error("SpatialPartition: group " + groupId + " is outside SPATIAL_PARTITION_MAX_GROUPS")
+	if not requireValidEntry(id) or not requireValidGroup(groupId) or not requireReady()
 		return
 	let isMember = cellOfEntry[groupSlot(id, groupId)] != 0
 	if member and not isMember
@@ -209,7 +230,11 @@ public function spatialPartitionSetGroup(int id, int groupId, boolean member)
 
 /** Whether an entry is currently in a group. */
 public function spatialPartitionInGroup(int id, int groupId) returns boolean
-	return id >= 1 and cellOfEntry[groupSlot(id, groupId)] != 0
+	// Quiet rather than loud: probing an id or group you do not own is a legitimate question, and the
+	// honest answer is "no" - but it must not be answered by another entry's slot.
+	if not spatialPartitionIsValidEntryId(id) or not spatialPartitionIsValidGroupId(groupId)
+		return false
+	return cellOfEntry[groupSlot(id, groupId)] != 0
 
 /** Drops an entry from every group. Call before recycling its id, or a later entry inherits it. */
 public function spatialPartitionRemove(int id)
@@ -356,13 +381,17 @@ public function spatialPartitionBeginRangeQuery(vec2 center, real radius, real m
 
 	return snapshotTop - queryBase[queryDepth - 1]
 
-/** Entry id `i` of the innermost active query. */
+/** Entry id `i` of the innermost active query, or 0 if there is no such result. */
 public function spatialPartitionQueryId(int i) returns int
+	if queryDepth <= 0 or i < 0 or queryBase[queryDepth - 1] + i >= snapshotTop
+		return 0
 	return snapshotId[queryBase[queryDepth - 1] + i]
 
 /**	Whether entry `i` could not be decided from its cached position and needs a live check against the
 	requested radius. Always false when the query passed a zero displacement. */
 public function spatialPartitionQueryUncertain(int i) returns boolean
+	if queryDepth <= 0 or i < 0 or queryBase[queryDepth - 1] + i >= snapshotTop
+		return false
 	return snapshotUncertain[queryBase[queryDepth - 1] + i]
 
 public function spatialPartitionEndQuery()

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -20,6 +20,9 @@ package SpatialPartition
 
 	Staleness is a query parameter, not state: a caller whose entries never move passes a zero
 	displacement and gets an exact answer with no undecidable band at all.
+
+	Entry ids are supplied by the owning layer and must be **1-based**: 0 is reserved as the chain
+	sentinel.
 */
 import ErrorHandling
 
@@ -125,6 +128,21 @@ public function spatialPartitionLastQueryBlocksSkipped() returns int
 
 // Membership
 
+/*	Entry ids are 1-based because 0 is the chain sentinel: `cellHead` and `nextInCell` use it to mean
+	"nothing here". An entry linked under id 0 would write that sentinel into the head, making itself
+	invisible to every query and, worse, letting a later unlink overwrite the real head and hide every
+	other entry in the same cell. Rejecting is cheaper than encoding ids as `id + 1`, which would put an
+	extra add and subtract in the hottest loop in the package. */
+/** Whether an id may be used as an entry. Ids are 1-based; 0 is reserved as the chain sentinel. */
+public function spatialPartitionIsValidEntryId(int id) returns boolean
+	return id >= 1
+
+function requireValidEntry(int id) returns boolean
+	if not spatialPartitionIsValidEntryId(id)
+		error("SpatialPartition: entry id " + id + " is invalid; ids are 1-based (0 is the chain sentinel)")
+		return false
+	return true
+
 function linkIntoCell(int id, int groupId, int cell)
 	let slot = groupSlot(id, groupId)
 	let head = cellHead[headSlot(cell, groupId)]
@@ -160,6 +178,8 @@ function unlinkFromCell(int id, int groupId)
 /**	Records where an entry is, re-bucketing it in every group it belongs to. Call this before adding
 	the entry to any group, and again whenever it has moved. */
 public function spatialPartitionSetPos(int id, real x, real y)
+	if not requireValidEntry(id)
+		return
 	entryX[id] = x
 	entryY[id] = y
 	if registrySlot[id] == 0
@@ -176,6 +196,8 @@ public function spatialPartitionSetPos(int id, real x, real y)
 /**	Adds or removes an entry from one group. The caller owns the policy of when membership changes,
 	which keeps predicate evaluation out of the walk entirely. */
 public function spatialPartitionSetGroup(int id, int groupId, boolean member)
+	if not requireValidEntry(id)
+		return
 	if groupId < 0 or groupId >= SPATIAL_PARTITION_MAX_GROUPS
 		error("SpatialPartition: group " + groupId + " is outside SPATIAL_PARTITION_MAX_GROUPS")
 		return
@@ -187,10 +209,12 @@ public function spatialPartitionSetGroup(int id, int groupId, boolean member)
 
 /** Whether an entry is currently in a group. */
 public function spatialPartitionInGroup(int id, int groupId) returns boolean
-	return cellOfEntry[groupSlot(id, groupId)] != 0
+	return id >= 1 and cellOfEntry[groupSlot(id, groupId)] != 0
 
 /** Drops an entry from every group. Call before recycling its id, or a later entry inherits it. */
 public function spatialPartitionRemove(int id)
+	if not requireValidEntry(id)
+		return
 	for groupId = 0 to SPATIAL_PARTITION_MAX_GROUPS - 1
 		unlinkFromCell(id, groupId)
 	entryX[id] = 0.
@@ -277,6 +301,9 @@ public function spatialPartitionBeginRangeQuery(vec2 center, real radius, real m
 		return 0
 
 	let reach = radius + maxDisplacement
+	// May go negative when the displacement exceeds the radius, in which case nothing can be decided
+	// from a cached position and every hit is flagged. Zero is still decisive, though: it means only an
+	// entry exactly on the point is certainly inside, which is what a point query asks for.
 	let certainlyIn = radius - maxDisplacement
 	let certainlyInSq = certainlyIn * certainlyIn
 	let certainlyOutSq = reach * reach
@@ -320,7 +347,7 @@ public function spatialPartitionBeginRangeQuery(vec2 center, real radius, real m
 							let dy = entryY[id] - center.y
 							let distSq = dx * dx + dy * dy
 							if distSq <= certainlyOutSq
-								pushMatch(id, not (certainlyIn > 0. and distSq <= certainlyInSq))
+								pushMatch(id, not (certainlyIn >= 0. and distSq <= certainlyInSq))
 							id = next
 						cx++
 					cy++

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -134,11 +134,39 @@ public function spatialPartitionCoarseWidth() returns int
 public function spatialPartitionCellSlotCount() returns int
 	return gridWidth * gridHeight * SPATIAL_PARTITION_MAX_GROUPS
 
-/** Slots the given extent would need, so a caller can size cells and groups before committing to it. */
+/** Cells an axis span needs, or -1 when that count cannot be represented as an int at all. */
+function cellsAcross(real span) returns int
+	let cells = span / SPATIAL_PARTITION_CELL_SIZE
+	// Checked in the real domain first: `.ceil()` on something past the int range is meaningless, so
+	// the conversion itself has to be refused rather than its result inspected afterwards.
+	if cells >= INT_MAX.toReal() - 2.
+		return -1
+	return cells.ceil() + 1
+
+/**	Cell-head slots the given extent would need, so a caller can size cells and groups before committing
+	to it - or -1 when that count is not representable, which is itself a reason to refuse the extent.
+
+	Computed with divisions rather than by multiplying and inspecting the result: at a small cell size
+	the product overflows, and a wrapped negative reads as "comfortably within budget" to any comparison
+	made afterwards. */
 public function spatialPartitionRequiredCellSlots(vec2 worldMin, vec2 worldMax) returns int
-	let w = ((worldMax.x - worldMin.x) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
-	let h = ((worldMax.y - worldMin.y) / SPATIAL_PARTITION_CELL_SIZE).ceil() + 1
-	return w * h * SPATIAL_PARTITION_MAX_GROUPS
+	if not spatialPartitionIsValidExtent(worldMin, worldMax)
+		return -1
+	let w = cellsAcross(worldMax.x - worldMin.x)
+	let h = cellsAcross(worldMax.y - worldMin.y)
+	if w < 0 or h < 0
+		return -1
+	if h > INT_MAX div SPATIAL_PARTITION_MAX_GROUPS
+		return -1
+	let perColumn = h * SPATIAL_PARTITION_MAX_GROUPS
+	if w > INT_MAX div perColumn
+		return -1
+	return w * perColumn
+
+/** Whether an extent's cell storage is both representable and within this target's array limit. */
+public function spatialPartitionExtentFits(vec2 worldMin, vec2 worldMax) returns boolean
+	let needed = spatialPartitionRequiredCellSlots(worldMin, worldMax)
+	return needed >= 0 and needed <= targetArrayLimit()
 
 /** Entries the last query walked, whether or not they matched. */
 public function spatialPartitionLastQueryVisits() returns int
@@ -326,10 +354,11 @@ public function rebuildSpatialPartition(vec2 worldMin, vec2 worldMax)
 	if not spatialPartitionIsValidExtent(worldMin, worldMax)
 		error("SpatialPartition: extent is inverted; worldMin must not exceed worldMax on either axis")
 		return
-	if spatialPartitionRequiredCellSlots(worldMin, worldMax) > targetArrayLimit()
+	if not spatialPartitionExtentFits(worldMin, worldMax)
 		error("SpatialPartition: that extent needs "
 			+ spatialPartitionRequiredCellSlots(worldMin, worldMax)
-			+ " cell slots, past this target's array limit of " + targetArrayLimit()
+			+ " cell slots (-1 meaning not even representable), past this target's array limit of "
+			+ targetArrayLimit()
 			+ "; raise SPATIAL_PARTITION_CELL_SIZE or lower SPATIAL_PARTITION_MAX_GROUPS")
 		return
 	// Old dimensions still describe the arrays being cleared, so clear before re-deriving them.

--- a/wurst/util/SpatialPartition.wurst
+++ b/wurst/util/SpatialPartition.wurst
@@ -26,10 +26,10 @@ package SpatialPartition
 
 	Like the indexes built on it, this targets **Lua**, where arrays grow dynamically. The cell chains
 	are flattened as `cell * MAX_GROUPS + groupId` and the per-entry links as `id * MAX_GROUPS + groupId`,
-	so both a grid extent and an entry id have a ceiling on Jass, where arrays are fixed at
-	`JASS_MAX_ARRAY_SIZE`. `rebuildSpatialPartition` refuses an extent past that ceiling and
-	`spatialPartitionMaxEntryId` reports the other, rather than either silently losing what it cannot
-	address.
+	so a grid extent, an entry id and the nesting depth of open queries all have ceilings on Jass, where
+	arrays are fixed at `JASS_MAX_ARRAY_SIZE`. Those ceilings are derived together rather than guarded
+	one array at a time - see the capacity section - so nothing is written where it cannot be found
+	again.
 */
 import ErrorHandling
 
@@ -45,6 +45,10 @@ import ErrorHandling
 /**	Concurrently declared groups. Each costs one chain pointer per entry and one head per cell, so
 	raise it only as far as a project uses. */
 @configurable public constant SPATIAL_PARTITION_MAX_GROUPS = 8
+
+/**	Deepest nesting of simultaneously open queries. Every open level keeps its own results in the shared
+	snapshot, so this multiplies snapshot storage and is part of the capacity budget below. */
+@configurable public constant SPATIAL_PARTITION_MAX_QUERY_DEPTH = 8
 
 // Grid state
 
@@ -151,15 +155,26 @@ public function spatialPartitionLastQueryBlocksSkipped() returns int
 	invisible to every query and, worse, letting a later unlink overwrite the real head and hide every
 	other entry in the same cell. Rejecting is cheaper than encoding ids as `id + 1`, which would put an
 	extra add and subtract in the hottest loop in the package. */
-/*	Both flattened address spaces are bounded by the target, and by the same constant.
+/*	Capacity, in one place, for every fixed array this package owns.
 
-	Cells are addressed as `cell * MAX_GROUPS + groupId` and entries as `id * MAX_GROUPS + groupId`, so
-	each has a ceiling on Jass where arrays are fixed. `rebuildSpatialPartition` enforces the first;
-	this enforces the second, and bounding entry ids covers the rest transitively - the snapshot and the
-	registry are indexed by counts that cannot exceed the live entries. On Lua arrays grow and neither
-	ceiling applies. */
+	There are four, and they are bounded by two different products - which is the whole reason this is
+	stated once rather than guarded where each array happens to be written:
+
+	  cells      `gridWidth * gridHeight * MAX_GROUPS`   - enforced by rebuildSpatialPartition
+	  entry links `id * MAX_GROUPS + groupId`            - bounds the entry id
+	  snapshot   `entries * MAX_QUERY_DEPTH`             - every OPEN query's results are live at once
+	  query base `MAX_QUERY_DEPTH`                       - bounds nesting itself
+
+	The snapshot is the one that is easy to get wrong, and I did: it is not bounded by the live entries,
+	because nested queries each keep their own results. Depth multiplies it. */
+function targetArrayLimit() returns int
+	return isLua ? INT_MAX : JASS_MAX_ARRAY_SIZE
+
+/**	Largest usable entry id on this target. Whichever of the two ceilings binds first: the flattened
+	per-entry links, or the snapshot with every query level open at once. Effectively unbounded on Lua. */
 public function spatialPartitionMaxEntryId() returns int
-	return isLua ? INT_MAX : JASS_MAX_ARRAY_SIZE div SPATIAL_PARTITION_MAX_GROUPS - 1
+	return min(targetArrayLimit() div SPATIAL_PARTITION_MAX_GROUPS - 1,
+		targetArrayLimit() div SPATIAL_PARTITION_MAX_QUERY_DEPTH)
 
 /**	Whether an id may be used as an entry. Ids are 1-based, because 0 is reserved as the chain
 	sentinel, and bounded above on Jass by what the flattened entry slots can address. */
@@ -173,6 +188,11 @@ public function spatialPartitionIsValidGroupId(int groupId) returns boolean
 /** Whether the grid has been given an extent yet. Nothing can be linked before it has. */
 public function spatialPartitionIsReady() returns boolean
 	return gridWidth > 0 and gridHeight > 0
+
+/**	Whether an extent describes a real area. An inverted axis yields a zero or negative dimension, and
+	the coarse block index divides by the grid width, so this has to be caught before any state moves. */
+public function spatialPartitionIsValidExtent(vec2 worldMin, vec2 worldMax) returns boolean
+	return worldMax.x >= worldMin.x and worldMax.y >= worldMin.y
 
 /*	Every public mutator validates through these, and every public reader answers quietly for input it
 	cannot honour. Both halves matter because the arrays are flattened with a constant stride: an
@@ -300,12 +320,16 @@ public function spatialPartitionClear()
 	entry still carrying its old link would be invisible to the new grid and would corrupt the chain it
 	is eventually unlinked from. */
 public function rebuildSpatialPartition(vec2 worldMin, vec2 worldMax)
-	// The flattened cell storage has to be representable on the target before anything is cleared, or
-	// the refusal would leave the partition in a worse state than it started.
-	if not isLua and spatialPartitionRequiredCellSlots(worldMin, worldMax) > JASS_MAX_ARRAY_SIZE
+	// Both checks run before anything is cleared: a refusal must leave the partition exactly as it was,
+	// not half-unlinked. An inverted axis passes the slot count trivially - a zero dimension needs zero
+	// slots - so it has to be rejected on its own terms.
+	if not spatialPartitionIsValidExtent(worldMin, worldMax)
+		error("SpatialPartition: extent is inverted; worldMin must not exceed worldMax on either axis")
+		return
+	if spatialPartitionRequiredCellSlots(worldMin, worldMax) > targetArrayLimit()
 		error("SpatialPartition: that extent needs "
 			+ spatialPartitionRequiredCellSlots(worldMin, worldMax)
-			+ " cell slots, past this target's array limit of " + JASS_MAX_ARRAY_SIZE
+			+ " cell slots, past this target's array limit of " + targetArrayLimit()
 			+ "; raise SPATIAL_PARTITION_CELL_SIZE or lower SPATIAL_PARTITION_MAX_GROUPS")
 		return
 	// Old dimensions still describe the arrays being cleared, so clear before re-deriving them.
@@ -356,11 +380,16 @@ public function rebuildSpatialPartition(vec2 worldMin, vec2 worldMax)
 	Must be paired with `spatialPartitionEndQuery()`. */
 public function spatialPartitionBeginRangeQuery(vec2 center, real radius, real maxDisplacement,
 		int groupId) returns int
+	// Depth is part of the capacity budget, not just a style limit: each open level's results sit in the
+	// shared snapshot simultaneously. Still pushes a level so a caller's paired endQuery stays balanced.
+	let tooDeep = queryDepth >= SPATIAL_PARTITION_MAX_QUERY_DEPTH
+	if tooDeep
+		error("SpatialPartition: queries nested deeper than " + SPATIAL_PARTITION_MAX_QUERY_DEPTH)
 	queryBase[queryDepth] = snapshotTop
 	queryDepth++
 	lastQueryVisits = 0
 	lastQueryBlocksSkipped = 0
-	if groupId < 0 or groupId >= SPATIAL_PARTITION_MAX_GROUPS or gridWidth <= 0
+	if tooDeep or not spatialPartitionIsValidGroupId(groupId) or not spatialPartitionIsReady()
 		return 0
 
 	let reach = radius + maxDisplacement

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -1,0 +1,196 @@
+package SpatialPartitionTests
+import SpatialPartition
+
+/*	The core is plain integer ids, so everything about it is testable directly: no units, no engine, no
+	backend. That is itself part of the point of extracting it. */
+
+constant ALL = 0
+constant SUBSET = 1
+
+function arena()
+	// Each test starts from an empty partition; otherwise one test's entries answer another's queries.
+	spatialPartitionClear()
+	rebuildSpatialPartition(vec2(-4096., -4096.), vec2(4096., 4096.))
+
+function place(int id, vec2 pos, int groupId)
+	spatialPartitionSetPos(id, pos.x, pos.y)
+	spatialPartitionSetGroup(id, groupId, true)
+
+function countIn(vec2 center, real radius, real maxDisplacement, int groupId) returns int
+	let n = spatialPartitionBeginRangeQuery(center, radius, maxDisplacement, groupId)
+	spatialPartitionEndQuery()
+	return n
+
+@Test function gridAndCoarseLevelCoverTheExtent()
+	arena()
+	// 8192 world units at 256 per cell, plus one so the far edge lands inside the grid.
+	spatialPartitionGridWidth().assertEquals(33)
+	spatialPartitionGridHeight().assertEquals(33)
+	// 33 fine cells at 8 per coarse block is 5 blocks across.
+	spatialPartitionCoarseWidth().assertEquals(5)
+
+@Test function entriesAreFoundWithinTheRadius()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(300., 0.), ALL)
+	place(3, vec2(3000., 0.), ALL)
+
+	countIn(vec2(0., 0.), 500., 0., ALL).assertEquals(2)
+	countIn(vec2(0., 0.), 4000., 0., ALL).assertEquals(3)
+	countIn(vec2(0., 0.), 100., 0., ALL).assertEquals(1)
+
+@Test function groupsAreIndependent()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(50., 0.), ALL)
+	spatialPartitionSetGroup(2, SUBSET, true)
+
+	countIn(vec2(0., 0.), 500., 0., ALL).assertEquals(2)
+	countIn(vec2(0., 0.), 500., 0., SUBSET).assertEquals(1)
+	spatialPartitionInGroup(1, SUBSET).assertFalse()
+	spatialPartitionInGroup(2, SUBSET).assertTrue()
+
+@Test function movingAnEntryRebucketsItInEveryGroup()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	spatialPartitionSetGroup(1, SUBSET, true)
+
+	spatialPartitionSetPos(1, 3000., 0.)
+	countIn(vec2(0., 0.), 300., 0., ALL).assertEquals(0)
+	countIn(vec2(0., 0.), 300., 0., SUBSET).assertEquals(0)
+	countIn(vec2(3000., 0.), 300., 0., ALL).assertEquals(1)
+	countIn(vec2(3000., 0.), 300., 0., SUBSET).assertEquals(1)
+
+/*	Ids get recycled by the owning layer, so a link left behind on removal would make the next entry to
+	take that id a member of a group nothing ever put it in. */
+@Test function removingAnEntryClearsEveryGroup()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	spatialPartitionSetGroup(1, SUBSET, true)
+	spatialPartitionRemove(1)
+
+	spatialPartitionInGroup(1, ALL).assertFalse()
+	spatialPartitionInGroup(1, SUBSET).assertFalse()
+	countIn(vec2(0., 0.), 500., 0., ALL).assertEquals(0)
+
+	// The id comes back as something else entirely and must start clean.
+	place(1, vec2(0., 0.), ALL)
+	spatialPartitionInGroup(1, SUBSET).assertFalse()
+
+/*	The whole reason staleness is a query parameter: a caller whose entries never move must never be
+	handed an undecidable result to go and re-check. */
+@Test function zeroDisplacementNeverFlagsAnEntry()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(399., 0.), ALL)
+
+	let n = spatialPartitionBeginRangeQuery(vec2(0., 0.), 400., 0., ALL)
+	n.assertEquals(2)
+	spatialPartitionQueryUncertain(0).assertFalse()
+	spatialPartitionQueryUncertain(1).assertFalse()
+	spatialPartitionEndQuery()
+
+/*	With movement allowed, only the band around the boundary is undecidable. Anything comfortably
+	inside is still answered from the cached position, which is what keeps the live reads rare. */
+@Test function onlyTheBoundaryBandIsFlaggedAsUncertain()
+	arena()
+	let drift = 100.
+	place(1, vec2(0., 0.), ALL)      // deep inside
+	place(2, vec2(350., 0.), ALL)    // within drift of the 400 boundary
+	place(3, vec2(450., 0.), ALL)    // outside, but reachable within drift
+
+	let n = spatialPartitionBeginRangeQuery(vec2(0., 0.), 400., drift, ALL)
+	n.assertEquals(3)
+	var certain = 0
+	var uncertain = 0
+	for i = 0 to n - 1
+		if spatialPartitionQueryUncertain(i)
+			uncertain++
+		else
+			certain++
+	spatialPartitionEndQuery()
+
+	// Only the deep one is decided; both boundary entries need a live check.
+	certain.assertEquals(1)
+	uncertain.assertEquals(2)
+
+	// Beyond radius + drift nothing is returned at all.
+	countIn(vec2(0., 0.), 400., drift, ALL).assertEquals(3)
+	countIn(vec2(0., 0.), 100., drift, ALL).assertEquals(1)
+
+/*	The coarse level earns its keep on the case a plain grid is worst at: a large radius over mostly
+	empty space. Without it the query walks every cell in the bounding box. */
+@Test function largeRadiusSkipsEmptyCoarseBlocks()
+	arena()
+	place(1, vec2(-3900., -3900.), ALL)
+	place(2, vec2(3900., 3900.), ALL)
+
+	let found = spatialPartitionBeginRangeQuery(vec2(0., 0.), 8000., 0., ALL)
+	let visits = spatialPartitionLastQueryVisits()
+	let skipped = spatialPartitionLastQueryBlocksSkipped()
+	spatialPartitionEndQuery()
+
+	println("[spatial-partition] radius 8000 over 2 entries: visited=" + visits
+		+ " coarse blocks skipped=" + skipped)
+
+	found.assertEquals(2)
+	// Two entries walked, not the ~1000 cells the bounding box covers.
+	visits.assertEquals(2)
+	// 5x5 blocks span the window; all but the two occupied corners are rejected outright.
+	skipped.assertEquals(23)
+
+/*	Magnitudes for the group split, on the shape groups exist for: a crowd nobody wants and a handful
+	of members inside it. */
+@Test function groupQueryWalksMembersNotTheCrowd()
+	arena()
+	let crowd = 600
+	let members = 40
+	for i = 0 to crowd - 1
+		let a = (i * 37 mod 360).toReal() * bj_DEGTORAD
+		let r = (i mod 11).toReal() * 90.
+		place(i + 1, vec2(r * Cos(a), r * Sin(a)), ALL)
+	for i = 0 to members - 1
+		let a = (i * 53 mod 360).toReal() * bj_DEGTORAD
+		let r = (i mod 11).toReal() * 90.
+		let id = crowd + i + 1
+		place(id, vec2(r * Cos(a), r * Sin(a)), ALL)
+		spatialPartitionSetGroup(id, SUBSET, true)
+
+	let plain = spatialPartitionBeginRangeQuery(vec2(0., 0.), 1200., 0., ALL)
+	let plainVisits = spatialPartitionLastQueryVisits()
+	spatialPartitionEndQuery()
+	let grouped = spatialPartitionBeginRangeQuery(vec2(0., 0.), 1200., 0., SUBSET)
+	let groupedVisits = spatialPartitionLastQueryVisits()
+	spatialPartitionEndQuery()
+
+	println("[spatial-partition] crowd=" + crowd + " members=" + members
+		+ " | all matched=" + plain + " visited=" + plainVisits
+		+ " | group matched=" + grouped + " visited=" + groupedVisits)
+
+	grouped.assertEquals(members)
+	plain.assertEquals(crowd + members)
+	// Entries walked is the real cost, and it must scale with the group rather than the crowd.
+	groupedVisits.assertEquals(members)
+	assertTrue(plainVisits > groupedVisits * 10,
+		"the group query should walk an order of magnitude fewer entries, got all=" + plainVisits
+		+ " group=" + groupedVisits)
+
+/*	Nested queries must not clobber each other: the snapshot is one shared stack, and a caller that
+	queries while iterating a result is the normal case in reactive code. */
+@Test function nestedQueriesKeepTheirOwnResults()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(3000., 0.), ALL)
+
+	let outer = spatialPartitionBeginRangeQuery(vec2(0., 0.), 500., 0., ALL)
+	outer.assertEquals(1)
+	let outerId = spatialPartitionQueryId(0)
+
+	let inner = spatialPartitionBeginRangeQuery(vec2(3000., 0.), 500., 0., ALL)
+	inner.assertEquals(1)
+	spatialPartitionQueryId(0).assertEquals(2)
+	spatialPartitionEndQuery()
+
+	// The outer result must survive the inner query untouched.
+	spatialPartitionQueryId(0).assertEquals(outerId)
+	spatialPartitionEndQuery()

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -219,6 +219,19 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	spatialPartitionIsValidEntryId(-7).assertFalse()
 	spatialPartitionIsValidEntryId(1).assertTrue()
 
+	/*	Bounded above as well as below, and by the same constant the extent guard uses: entry links are
+		flattened as `id * MAX_GROUPS + groupId`, so on Jass id 4096 at eight groups addresses slot
+		32768 - already past the array limit. An id the target cannot address has to be refused, not
+		written somewhere it will not be found again. */
+	let maxId = spatialPartitionMaxEntryId()
+	spatialPartitionIsValidEntryId(maxId).assertTrue()
+	spatialPartitionIsValidEntryId(maxId + 1).assertFalse()
+	if not isLua
+		maxId.assertEquals(JASS_MAX_ARRAY_SIZE div SPATIAL_PARTITION_MAX_GROUPS - 1)
+		// The reported case: the first id whose slot falls outside the array.
+		spatialPartitionIsValidEntryId(4096).assertFalse()
+		(4096 * SPATIAL_PARTITION_MAX_GROUPS).assertEquals(JASS_MAX_ARRAY_SIZE)
+
 	spatialPartitionIsValidGroupId(-1).assertFalse()
 	spatialPartitionIsValidGroupId(SPATIAL_PARTITION_MAX_GROUPS).assertFalse()
 	spatialPartitionIsValidGroupId(0).assertTrue()

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -194,3 +194,37 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	// The outer result must survive the inner query untouched.
 	spatialPartitionQueryId(0).assertEquals(outerId)
 	spatialPartitionEndQuery()
+
+/*	A point query is a legitimate use, and with nothing allowed to have moved its answer is exact. The
+	certain/uncertain split therefore has to treat a zero inner radius as decisive rather than as "no
+	inner radius at all", or a caller doing point lookups is sent to re-check every hit against a live
+	position it was promised it would not need. */
+@Test function zeroRadiusStillDecidesAnExactHit()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(1., 0.), ALL)
+
+	let n = spatialPartitionBeginRangeQuery(vec2(0., 0.), 0., 0., ALL)
+	n.assertEquals(1)
+	spatialPartitionQueryId(0).assertEquals(1)
+	spatialPartitionQueryUncertain(0).assertFalse()
+	spatialPartitionEndQuery()
+
+/*	Ids are 1-based because 0 is the chain sentinel. An entry accepted under id 0 would write "empty"
+	into the cell head: invisible itself, and able to hide every other entry in the same cell the next
+	time it was unlinked.
+
+	The rule is asserted rather than the symptom: every mutator rejects a bad id through `error()`,
+	which aborts, so the corruption it prevents cannot be provoked from a test. `spatialPartitionInGroup`
+	is the one reader that must stay quiet, since callers legitimately ask about ids they do not own. */
+@Test function entryIdsAreOneBasedBecauseZeroIsTheSentinel()
+	spatialPartitionIsValidEntryId(0).assertFalse()
+	spatialPartitionIsValidEntryId(-7).assertFalse()
+	spatialPartitionIsValidEntryId(1).assertTrue()
+	spatialPartitionIsValidEntryId(9999).assertTrue()
+
+	arena()
+	place(1, vec2(0., 0.), ALL)
+	place(2, vec2(50., 0.), ALL)
+	spatialPartitionInGroup(0, ALL).assertFalse()
+	countIn(vec2(0., 0.), 500., 0., ALL).assertEquals(2)

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -260,3 +260,22 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	spatialPartitionClear()
 	rebuildSpatialPartition(vec2(-1024., -1024.), vec2(1024., 1024.))
 	spatialPartitionIsReady().assertTrue()
+
+/*	The cell chains are flattened as `cell * MAX_GROUPS + groupId`, so the storage a grid needs grows
+	with area x groups. On Lua that is only a memory figure, but on Jass it is bounded by
+	JASS_MAX_ARRAY_SIZE, and the cells past the limit would simply be unrepresentable - entries in them
+	invisible to every query. The rule is asserted rather than the refusal, which goes through `error()`
+	and aborts. */
+@Test function flattenedCellStorageStaysWithinTheTargetLimit()
+	// The extent these tests use is comfortably inside the Jass limit.
+	arena()
+	spatialPartitionCellSlotCount().assertEquals(33 * 33 * SPATIAL_PARTITION_MAX_GROUPS)
+	assertTrue(spatialPartitionCellSlotCount() <= JASS_MAX_ARRAY_SIZE,
+		"the test extent should be representable on any target, needs "
+		+ spatialPartitionCellSlotCount())
+
+	// A 16384-unit world at the default 256 cell and 8 groups is not: 65 x 65 x 8 = 33800.
+	let big = spatialPartitionRequiredCellSlots(vec2(-8192., -8192.), vec2(8192., 8192.))
+	big.assertEquals(65 * 65 * SPATIAL_PARTITION_MAX_GROUPS)
+	assertTrue(big > JASS_MAX_ARRAY_SIZE,
+		"this extent is the one the guard exists for, needs " + big)

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -210,21 +210,53 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	spatialPartitionQueryUncertain(0).assertFalse()
 	spatialPartitionEndQuery()
 
-/*	Ids are 1-based because 0 is the chain sentinel. An entry accepted under id 0 would write "empty"
-	into the cell head: invisible itself, and able to hide every other entry in the same cell the next
-	time it was unlinked.
-
-	The rule is asserted rather than the symptom: every mutator rejects a bad id through `error()`,
-	which aborts, so the corruption it prevents cannot be provoked from a test. `spatialPartitionInGroup`
-	is the one reader that must stay quiet, since callers legitimately ask about ids they do not own. */
-@Test function entryIdsAreOneBasedBecauseZeroIsTheSentinel()
+/*	The flattened stride is what makes these matter. An out-of-range id does not fail, it ALIASES: at
+	the default stride of 8, group 8 of entry 1 is the same slot as group 0 of entry 2, so an
+	unvalidated lookup answers confidently with someone else's membership. These assert the rules for
+	every public reader, since the mutators enforce theirs through `error()`, which aborts a test. */
+@Test function idAndGroupRulesAreStatedOnce()
 	spatialPartitionIsValidEntryId(0).assertFalse()
 	spatialPartitionIsValidEntryId(-7).assertFalse()
 	spatialPartitionIsValidEntryId(1).assertTrue()
-	spatialPartitionIsValidEntryId(9999).assertTrue()
 
+	spatialPartitionIsValidGroupId(-1).assertFalse()
+	spatialPartitionIsValidGroupId(SPATIAL_PARTITION_MAX_GROUPS).assertFalse()
+	spatialPartitionIsValidGroupId(0).assertTrue()
+	spatialPartitionIsValidGroupId(SPATIAL_PARTITION_MAX_GROUPS - 1).assertTrue()
+
+@Test function membershipLookupCannotAliasAnotherEntry()
 	arena()
 	place(1, vec2(0., 0.), ALL)
 	place(2, vec2(50., 0.), ALL)
+
+	// Entry 2 really is in group 0, and that slot is exactly where entry 1 group 8 would land.
+	spatialPartitionInGroup(2, ALL).assertTrue()
+	spatialPartitionInGroup(1, SPATIAL_PARTITION_MAX_GROUPS).assertFalse()
+	spatialPartitionInGroup(1, -1).assertFalse()
 	spatialPartitionInGroup(0, ALL).assertFalse()
-	countIn(vec2(0., 0.), 500., 0., ALL).assertEquals(2)
+
+/*	A result index outside the active query, or no active query at all, must not read whatever the
+	shared snapshot happens to hold - and `queryBase[queryDepth - 1]` with no query open indexes -1. */
+@Test function queryReadersAreBoundedToTheActiveResult()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+
+	// No query open.
+	spatialPartitionQueryId(0).assertEquals(0)
+	spatialPartitionQueryUncertain(0).assertFalse()
+
+	let n = spatialPartitionBeginRangeQuery(vec2(0., 0.), 500., 0., ALL)
+	n.assertEquals(1)
+	spatialPartitionQueryId(0).assertEquals(1)
+	// Past the end of this query, and before its start.
+	spatialPartitionQueryId(1).assertEquals(0)
+	spatialPartitionQueryId(-1).assertEquals(0)
+	spatialPartitionQueryUncertain(1).assertFalse()
+	spatialPartitionEndQuery()
+
+/*	Nothing can be linked before the grid has an extent: the coarse block index divides by the grid
+	width, so a mutator reaching it on a zero-width grid fails at runtime rather than misbehaving. */
+@Test function theGridReportsWhetherItIsReady()
+	spatialPartitionClear()
+	rebuildSpatialPartition(vec2(-1024., -1024.), vec2(1024., 1024.))
+	spatialPartitionIsReady().assertTrue()

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -292,3 +292,46 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	big.assertEquals(65 * 65 * SPATIAL_PARTITION_MAX_GROUPS)
 	assertTrue(big > JASS_MAX_ARRAY_SIZE,
 		"this extent is the one the guard exists for, needs " + big)
+
+/*	The capacity budget covers four fixed arrays, and the snapshot is the one that is easy to get wrong:
+	nested queries each keep their own results, so it scales with entries x depth, not entries.
+
+	Honest limitation: at the default MAX_GROUPS and MAX_QUERY_DEPTH of 8 the two ceilings coincide
+	(4095 x 8 = 32760), so this cannot fail as configured today. Both are @configurable, and raising
+	either is exactly when the budget stops being obvious - which is what this is here to catch. The
+	reported nine-deep scenario is refused by the depth bound rather than by this. */
+@Test function entryCeilingAccountsForNestedSnapshots()
+	let maxId = spatialPartitionMaxEntryId()
+	if not isLua
+		// Whichever of the two products binds first.
+		assertTrue(maxId * SPATIAL_PARTITION_MAX_GROUPS < JASS_MAX_ARRAY_SIZE,
+			"entry links must fit, needs " + (maxId * SPATIAL_PARTITION_MAX_GROUPS))
+		assertTrue(maxId * SPATIAL_PARTITION_MAX_QUERY_DEPTH <= JASS_MAX_ARRAY_SIZE,
+			"every query level open at once must fit, needs "
+			+ (maxId * SPATIAL_PARTITION_MAX_QUERY_DEPTH))
+
+/*	Nesting is itself part of the budget, so it is bounded rather than left to grow. */
+@Test function nestingIsBoundedAndStaysBalanced()
+	arena()
+	place(1, vec2(0., 0.), ALL)
+
+	// Open every permitted level; each still answers for itself.
+	for i = 1 to SPATIAL_PARTITION_MAX_QUERY_DEPTH
+		spatialPartitionBeginRangeQuery(vec2(0., 0.), 500., 0., ALL).assertEquals(1)
+	for i = 1 to SPATIAL_PARTITION_MAX_QUERY_DEPTH
+		spatialPartitionEndQuery()
+
+	// And the stack unwound completely rather than leaking a level.
+	spatialPartitionBeginRangeQuery(vec2(0., 0.), 500., 0., ALL).assertEquals(1)
+	spatialPartitionEndQuery()
+
+/*	An inverted extent yields a zero dimension, which needs zero cell slots and so sails through the
+	capacity guard - then divides by zero in the coarse block index. It has to be rejected on its own
+	terms, and before any state moves, or a refusal leaves the partition half-unlinked. */
+@Test function invertedExtentsAreRejected()
+	spatialPartitionIsValidExtent(vec2(-100., -100.), vec2(100., 100.)).assertTrue()
+	spatialPartitionIsValidExtent(vec2(0., 0.), vec2(0., 0.)).assertTrue()
+	spatialPartitionIsValidExtent(vec2(100., 0.), vec2(-100., 0.)).assertFalse()
+	spatialPartitionIsValidExtent(vec2(0., 100.), vec2(0., -100.)).assertFalse()
+	// The reported case: a span of exactly one negative cell.
+	spatialPartitionIsValidExtent(vec2(0., 0.), vec2(-SPATIAL_PARTITION_CELL_SIZE, 0.)).assertFalse()

--- a/wurst/util/SpatialPartitionTests.wurst
+++ b/wurst/util/SpatialPartitionTests.wurst
@@ -335,3 +335,25 @@ function countIn(vec2 center, real radius, real maxDisplacement, int groupId) re
 	spatialPartitionIsValidExtent(vec2(0., 100.), vec2(0., -100.)).assertFalse()
 	// The reported case: a span of exactly one negative cell.
 	spatialPartitionIsValidExtent(vec2(0., 0.), vec2(-SPATIAL_PARTITION_CELL_SIZE, 0.)).assertFalse()
+
+/*	The capacity guard has to survive its own arithmetic. At the default 256 cell an extent of a few
+	million units needs more slots than an int can hold, and the product wraps NEGATIVE - which reads as
+	"comfortably within budget" to the comparison that follows, so the guard waves through exactly the
+	grid it exists to refuse. Reported against a 1-unit cell size; it reproduces at the default too,
+	which is why the check divides instead of multiplying. */
+@Test function capacityCheckSurvivesItsOwnArithmetic()
+	// 16407 x 16407 x 8 overflows a signed int.
+	let huge = spatialPartitionRequiredCellSlots(vec2(-2100000., -2100000.), vec2(2100000., 2100000.))
+	huge.assertEquals(-1)
+	spatialPartitionExtentFits(vec2(-2100000., -2100000.), vec2(2100000., 2100000.)).assertFalse()
+
+	// A span past what the cell division can even convert to an int.
+	spatialPartitionRequiredCellSlots(vec2(0., 0.), vec2(1000000000000., 1.)).assertEquals(-1)
+
+	// An inverted extent has no slot count either, rather than a misleading one.
+	spatialPartitionRequiredCellSlots(vec2(100., 0.), vec2(-100., 0.)).assertEquals(-1)
+
+	// And an ordinary extent still reports a real figure and fits.
+	let ok = spatialPartitionRequiredCellSlots(vec2(-4096., -4096.), vec2(4096., 4096.))
+	ok.assertEquals(33 * 33 * SPATIAL_PARTITION_MAX_GROUPS)
+	spatialPartitionExtentFits(vec2(-4096., -4096.), vec2(4096., 4096.)).assertTrue()


### PR DESCRIPTION
## What this is

Groundwork for collapsing the two spatial indexes onto one structure.

`UnitSpatialIndex` and `DestructableSpatialIndex` currently each carry their own copy of the same grid — `cellCoordX`/`cellCoordY`/`cellAt`, `gridWidth`/`gridHeight`/origin, the rebuild, the query snapshot stack — and the two copies have already diverged in implementation: one on flat arrays, the other on `ArrayList` and class records. This PR extracts that structure and gives it a single owner.

`SpatialPartition` knows integer entry ids, positions and group membership. It knows nothing about units, destructables, staleness, or what "visible" means. Those stay with the consuming layer.

## Design, and why

Three properties chosen with the emitted Lua in mind:

- **No allocation per query.** Every buffer is a preallocated flat array; results are read from a shared snapshot stack. Wurst arrays become Lua tables, and a flat table with index arithmetic is one array-part lookup where a nested table would be two.
- **No calls in the walk.** Membership is *pushed in* by the caller rather than pulled through a predicate, and an undecidable position is reported as a flag for the caller to resolve rather than dispatched through an interface. A call per entry is the most expensive thing this loop could do.
- **Empty space is skipped, not walked.** A coarse occupancy level over the fine grid turns a large radius into one test per block instead of one per cell.

Two decisions are what let one structure serve both consumers:

- **Staleness is a query parameter, not state.** A caller whose entries never move passes zero displacement and gets an exact answer with no undecidable band at all; a caller with moving entries passes its own bound. Neither pays for the other's concerns.
- **Group membership is set by the owning layer.** That keeps predicate evaluation — the expensive part — out of the structure and under the policy of whoever actually knows when it can change.

The partition keeps a dense registry of live entries. Not for iteration: a rebuild changes what every cell index means, so every entry must be re-linked, and an owning layer cannot do that through an API that has already forgotten them. The same registry is what a future large-window early-out would iterate.

## Measured

From the test output:

```
radius 8000 over 2 entries: visited=2  coarse blocks skipped=23
crowd=600 members=40 | all matched=640 visited=640 | group matched=40 visited=40
```

The bounding box for that first query covers roughly a thousand cells; the coarse level reduces it to 25 block tests and 2 entry visits. The second is the case groups exist for — same answer, 16x fewer entries walked. Filtering the result of a plain query cannot recover this, because the walk has already happened.

## Acceptance criteria

- [x] Generic over integer ids; no unit or destructable knowledge in the core
- [x] Zero allocation and zero calls in the query walk
- [x] Large-radius queries skip empty regions
- [x] Group queries cost members, not the crowd
- [x] Rebuild is self-consistent — entries survive an extent change in the groups they were in
- [x] Directly unit-testable without units, the engine, or a specific backend

## Checks

- `grill typecheck`: 0 errors; warnings unchanged at the pre-existing 32
- `grill test`: 474/474 (10 new)

Tests cover membership, group isolation, re-bucketing on movement, id reuse after removal, the uncertain band at both displacement settings, the coarse skip, nested queries, and the group-vs-crowd cost.

## Known gaps, deliberately not in this PR

- **Nothing consumes it yet.** `UnitSpatialIndex` and `DestructableSpatialIndex` are untouched here. Porting them is the next step and is where the duplication actually dies.
- **Cell size will need a decision at that point.** The two indexes currently use 256 and 128; sharing one grid means either agreeing on a value or giving the core per-group cell sizes.
- **No large-window early-out yet.** Once a query window covers most of the registry, iterating the registry directly beats walking cells. The registry and the visit counter are both in place for it.
- **A quadtree was considered and not chosen.** For "collect everything in radius" the output is already O(matches), so a quadtree's advantage is only in *rejecting* empty space — which the coarse level buys far more cheaply — while the dominant workload is moving entries, where grid relink is O(1) and quadtree insert/remove/rebalance is not. Worth revisiting only with a benchmark that shows the grid losing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)