### PR TITLE
Write live positions back into the spatial index cache during a query

### DIFF
--- a/wurst/util/UnitSpatialIndex.wurst
+++ b/wurst/util/UnitSpatialIndex.wurst
@@ -375,8 +375,19 @@ public function spatialIndexBeginQuery(vec2 center, real radius, boolean collisi
 					// Only this annulus needs a live position read.
 					let u = indexedUnit[idx]
 					if u != null
-						let ux = u.getX() - center.x
-						let uy = u.getY() - center.y
+						let liveX = u.getX()
+						let liveY = u.getY()
+						// The live read was paid for anyway, so keep it: the next query in the same
+						// frame then decides this unit from the cache instead of reading it again.
+						// Only while the unit is still in its linked cell, though. Relinking here
+						// could move it into a cell this walk has not reached yet, and it would be
+						// visited and pushed a second time.
+						if cellOfUnit[idx] == cellAt(liveX, liveY) + 1
+							lastX[idx] = liveX
+							lastY[idx] = liveY
+							lastSweepTick[idx] = sweepTick
+						let ux = liveX - center.x
+						let uy = liveY - center.y
 						if ux * ux + uy * uy <= radiusSq and u.passesEnumerationState()
 							pushMatch(u)
 				idx = next

--- a/wurst/util/UnitSpatialIndex.wurst
+++ b/wurst/util/UnitSpatialIndex.wurst
@@ -99,9 +99,15 @@ function noteRegistryChange()
 	cycleMembershipStable = false
 	displacementBoundTicks = max(displacementBoundTicks, requiredSweepCycleTicks())
 
-/** Worst-case distance a unit may have travelled since its cached position was written. */
+/**	Worst-case distance a unit may travel during a single sweep tick. An entry cached `age` ticks
+	ago needs `age + 1` of these, because its write and the query may sit at opposite ends of their
+	own ticks; `displacementBoundTicks` carries the same extra tick over `requiredSweepCycleTicks`. */
+function tickDisplacement() returns real
+	return SPATIAL_INDEX_MAX_UNIT_SPEED * SPATIAL_INDEX_SWEEP_PERIOD
+
+/** Worst-case distance any indexed unit may have travelled since its cached position was written. */
 function currentMaxDisplacement() returns real
-	return SPATIAL_INDEX_MAX_UNIT_SPEED * displacementBoundTicks * SPATIAL_INDEX_SWEEP_PERIOD
+	return tickDisplacement() * displacementBoundTicks
 
 // Membership
 
@@ -331,7 +337,8 @@ public function spatialIndexBeginQuery(vec2 center, real radius, boolean collisi
 	queryBase[queryDepth] = snapshotTop
 	queryDepth++
 
-	let maxDisp = currentMaxDisplacement()
+	let tickDisp = tickDisplacement()
+	let maxDisp = tickDisp * displacementBoundTicks
 	// The engine test for the collision variant reaches an extra collision radius outward, so the
 	// window has to widen by the largest collision size any unit can have.
 	let reach = radius + (collisionSizeFiltering ? MAX_COLLISION_SIZE : 0.) + maxDisp
@@ -372,24 +379,38 @@ public function spatialIndexBeginQuery(vec2 center, real radius, boolean collisi
 					if u != null and u.passesEnumerationState()
 						pushMatch(u)
 				else if cachedDistSq <= certainlyOutSq
-					// Only this annulus needs a live position read.
-					let u = indexedUnit[idx]
-					if u != null
-						let liveX = u.getX()
-						let liveY = u.getY()
-						// The live read was paid for anyway, so keep it: the next query in the same
-						// frame then decides this unit from the cache instead of reading it again.
-						// Only while the unit is still in its linked cell, though. Relinking here
-						// could move it into a cell this walk has not reached yet, and it would be
-						// visited and pushed a second time.
-						if cellOfUnit[idx] == cellAt(liveX, liveY) + 1
-							lastX[idx] = liveX
-							lastY[idx] = liveY
-							lastSweepTick[idx] = sweepTick
-						let ux = liveX - center.x
-						let uy = liveY - center.y
-						if ux * ux + uy * uy <= radiusSq and u.passesEnumerationState()
+					// The bands above pad by the worst staleness anywhere in the registry. This entry can
+					// be far fresher than that - the sweep, a move event, or an earlier query in the same
+					// frame may have written it - so re-test against the padding it actually needs. Inside
+					// the inner band it matches, outside the outer one it does not, and only what is left
+					// between them costs two natives.
+					let entryDisp = tickDisp * (sweepTick - lastSweepTick[idx] + 1)
+					let entryIn = radius - entryDisp
+					let entryOut = radius + entryDisp
+					if entryIn > 0. and cachedDistSq <= entryIn * entryIn
+						let u = indexedUnit[idx]
+						if u != null and u.passesEnumerationState()
 							pushMatch(u)
+					else if cachedDistSq <= entryOut * entryOut
+						// Only this narrowed annulus needs a live position read.
+						let u = indexedUnit[idx]
+						if u != null
+							let liveX = u.getX()
+							let liveY = u.getY()
+							// The live read was paid for anyway, so keep it and stamp the tick: a later query
+							// in this frame then sees age 0, and its annulus is one tick of movement wide
+							// rather than a whole sweep cycle, so it decides this unit from the cache.
+							// Only while the unit is still in its linked cell, though. Relinking here could
+							// move it into a cell this walk has not reached yet, and it would be visited and
+							// pushed a second time.
+							if cellOfUnit[idx] == cellAt(liveX, liveY) + 1
+								lastX[idx] = liveX
+								lastY[idx] = liveY
+								lastSweepTick[idx] = sweepTick
+							let ux = liveX - center.x
+							let uy = liveY - center.y
+							if ux * ux + uy * uy <= radiusSq and u.passesEnumerationState()
+								pushMatch(u)
 				idx = next
 			cx++
 		cy++


### PR DESCRIPTION
## What

In `spatialIndexBeginQuery`, the annulus branch (cached distance between `certainlyIn` and `certainlyOut`) reads the unit's live position to decide the match. That position was discarded. It is now written back into `lastX`/`lastY` with the current sweep tick, so the next query in the same frame decides that unit from the cache and skips the two natives.

## Per-entry padding

The stamp is only worth writing if something reads it. `certainlyIn`/`certainlyOut` come from the global `maxDisp`, the worst staleness of any entry in the registry, so on its own the write-back changed nothing: a stationary boundary unit fell into the annulus again on the next query with the same center and radius and read both natives a second time.

The annulus branch therefore re-tests against the padding the entry itself needs, `tickDisplacement() * (age + 1)`, before deciding to read. The extra tick covers the cache write and the query sitting at opposite ends of their own ticks, which is the slack `displacementBoundTicks` already carries over `requiredSweepCycleTicks()`; `currentMaxDisplacement()` is now that same expression at the worst age, so the two bounds cannot drift apart.

After a write-back the age is 0, so the band is one tick of movement wide rather than a whole sweep cycle. At 500 units and 128 per tick `displacementBoundTicks` is 5, so the second query in the frame sees an annulus a fifth as wide, about ±16 world units instead of ±82.

The cell window and the outer bands stay on the global bound: the window is chosen before any entry is known, and the outer bands are the cheap reject that keeps most entries out of this arithmetic. `spatialIndexBeginBoxQuery` has the same split and the same discarded live read but no write-back, so giving it one is a separate change.

## Why not relink

Calling `refreshUnit` here would be wrong: a relink can move the unit into a cell the walk has not visited yet, and it would be visited and pushed twice. The write-back therefore happens only while the unit is still in its linked cell. Displacement is bounded well under one cell edge, so this covers nearly every case, and the invariant that a cached position lies in its linked cell holds.

## Context

Found while reading the emitted Lua for the synchronized-cast case (12+ range queries over 500+ units in one frame). The larger costs there are compiler-side and are specified in `LUA_HOT_PATH_SPEC.md` in the WurstScript repo (wurstscript/WurstScript#1284). This is the one stdlib-side change that is independent of those.

## Checks

- `grill typecheck`: succeeded
- `grill test` (full suite): all tests succeeded
- Soundness of the narrowed band is argued above rather than tested: the interpreter has no units, so `UnitSpatialIndexTests` covers grid arithmetic only and every query path is asserted in `StdlibIngameTests`
- The ingame parity tests (`StdlibIngameTests`) need a running map and were not run here.


