### PR TITLE
Stamp the sweep tick where the grid rebuild reads live positions

### DIFF
--- a/wurst/util/UnitSpatialIndex.wurst
+++ b/wurst/util/UnitSpatialIndex.wurst
@@ -304,6 +304,9 @@ public function rebuildSpatialIndexGrid(vec2 worldMin, vec2 worldMax)
 		let u = indexedUnit[idx]
 		if u != null
 			let pos = u.getPos()
+			// Stamp the tick wherever a live position is read, or the query would keep padding this
+			// entry by a full sweep cycle despite its cache having just been made exact.
+			lastSweepTick[idx] = sweepTick
 			linkIntoCell(idx, cellAt(pos.x, pos.y), pos.x, pos.y)
 
 /** Internal-grid cell for tests and diagnostics. */


### PR DESCRIPTION
## What

Follow-up to #473, which merged while this commit was in flight, so it missed the squash.

`rebuildSpatialIndexGrid` re-buckets every unit from a fresh `getPos`, but was the one site that cached a live position without recording when it read it. Every other one does: `registerUnit`, `refreshUnit` on both branches, and the query write-back added in #473.

## Why it matters now

While `lastSweepTick` fed nothing but the sweep's worst-age counter, a missing stamp only skewed a diagnostic. #473 made the query derive an entry's padding from it, so after a rebuild every entry looks maximally stale even though its cache was just made exact. Queries then pad by a whole sweep cycle and re-read positions they already hold, until the sweep works its way around — five ticks at 500 units and 128 per tick.

## Why not inside linkIntoCell

The stamp belongs with the read, not with the link. Putting it in `linkIntoCell` would tie freshness to bucketing and silently depend on every future caller passing a live position; a caller that re-links a cached position would then stamp it fresh, which is the one direction that returns wrong results rather than slow ones.

## Checks

- `grill typecheck`: succeeded
- `grill test UnitSpatialIndexTests`: 5/5, and the full `grill test` suite passed on this change before #473 merged
- Grid arithmetic is all the interpreter can cover here; the query paths are asserted in `StdlibIngameTests`, which needs a running map
